### PR TITLE
chore: force next oxlint-plugin-awscdk release to 1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -30,7 +30,8 @@
       "release-type": "node",
       "component": "oxlint-plugin-awscdk",
       "package-name": "oxlint-plugin-awscdk",
-      "bump-minor-pre-major": true
+      "bump-minor-pre-major": true,
+      "release-as": "1.0.0"
     }
   }
 }


### PR DESCRIPTION
### Reason for this change

The `Release-As: 1.0.0` footer on #522 did not survive the squash merge (the squash commit carries the PR title only), so release-please proposed `0.2.0` in #523 via `bump-minor-pre-major`. Setting `release-as` in the manifest config forces the next release to `1.0.0` without depending on commit-message plumbing.

### Description of changes

- Set `release-as: 1.0.0` for `packages/oxlint` in the release-please manifest config.
- This field is sticky: it should be removed in a follow-up once the `1.0.0` release PR has been merged.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
