### PR TITLE
chore: remove release-as after oxlint-plugin-awscdk 1.0.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -29,9 +29,7 @@
     "packages/oxlint": {
       "release-type": "node",
       "component": "oxlint-plugin-awscdk",
-      "package-name": "oxlint-plugin-awscdk",
-      "bump-minor-pre-major": true,
-      "release-as": "1.0.0"
+      "package-name": "oxlint-plugin-awscdk"
     }
   }
 }


### PR DESCRIPTION
### Reason for this change

`release-as: 1.0.0` (added in #524) is sticky: leaving it in place would force every future `oxlint-plugin-awscdk` release to `1.0.0`. Now that the release has shipped, it must be removed.

### Description of changes

- Remove `release-as` for `packages/oxlint`.
- Also remove `bump-minor-pre-major`, which only applies to pre-1.0 versions and is now dead config.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
