### PR TITLE
fix(oxlint-plugin-awscdk): align oxlint peer range with corsa-oxlint

### DIFF
--- a/packages/oxlint/package.json
+++ b/packages/oxlint/package.json
@@ -60,7 +60,7 @@
     "vite-plus": "^0.2.9"
   },
   "peerDependencies": {
-    "oxlint": "^1.79.0"
+    "oxlint": "^1.69.0"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0"


### PR DESCRIPTION
### Reason for this change

#525 mechanically raised the `oxlint` peer range to `^1.79.0` alongside the devDependency bump, narrowing consumer support without a technical need. The plugin's actual compatibility floor comes from `corsa-oxlint`, which declares `oxlint: ^1.69.0` as its peer.

### Description of changes

- Align `peerDependencies.oxlint` with the peer range declared by the bundled `corsa-oxlint` version. The devDependency stays on the latest oxlint for CI.

### Description of how you validated changes

- Unit tests (492/492), build, and checks all pass.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
