### PR TITLE
chore: ignore typescript major updates in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # typescript-eslint rejects TS 7 at load time; drop this once it supports TS 7
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
### Reason for this change

Dependabot keeps proposing the TypeScript 6 -> 7 major bump for `packages/eslint` and `examples` (#525, #530), but `typescript-eslint` rejects TS 7 at load time (`typescript-eslint does not support TS 7.0.`), so the proposal can never pass CI. Only `packages/oxlint` runs on TS 7, and its in-major updates are unaffected by this ignore.

### Description of changes

- Ignore `version-update:semver-major` for `typescript` in the npm update config. Drop the entry once typescript-eslint supports TS 7.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
