### PR TITLE
fix: no-variable-construct-id false positive for function expressions

### DIFF
--- a/packages/eslint/src/__tests__/no-variable-construct-id.test.ts
+++ b/packages/eslint/src/__tests__/no-variable-construct-id.test.ts
@@ -243,6 +243,41 @@ ruleTester.run("no-variable-construct-id", noVariableConstructId, {
       }
       `,
     },
+    // WHEN: new expression is inside a standalone function expression (no class context)
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      const createResource = function (scope: Construct, id: string) {
+        new TargetConstruct(scope, id);
+      };
+      `,
+    },
+    // WHEN: id is variable in a function expression assigned in constructor
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const myFunction = function (id: string, num: number) {
+            return new TargetConstruct(this, id + num);
+          };
+          myFunction('id', 1);
+          myFunction('id', 2);
+        }
+      }
+      `,
+    },
     // WHEN: new expression is inside a class that does not extend Construct
     {
       code: `

--- a/packages/eslint/src/rules/no-variable-construct-id.ts
+++ b/packages/eslint/src/rules/no-variable-construct-id.ts
@@ -77,7 +77,7 @@ const validateConstructId = (node: TSESTree.NewExpression, context: Context) => 
 
 /**
  * Check if construct ID validation should be skipped for a node.
- * Skip if it is inside a loop statement, non-constructor method, or arrow function.
+ * Skip if it is inside a loop statement, non-constructor method, or function other than a constructor.
  */
 const shouldSkipIdValidation = (node: TSESTree.Node): boolean => {
   let current = node.parent;
@@ -108,6 +108,15 @@ const shouldSkipIdValidation = (node: TSESTree.Node): boolean => {
     // Constructs in standalone functions (outside of classes) are intended to be called
     // multiple times with different IDs
     if (current.type === AST_NODE_TYPES.FunctionDeclaration) {
+      return true;
+    }
+
+    // Constructs in function expressions are also intended to be called multiple times.
+    // A constructor body is a FunctionExpression under MethodDefinition and must stay validated.
+    if (
+      current.type === AST_NODE_TYPES.FunctionExpression &&
+      current.parent?.type !== AST_NODE_TYPES.MethodDefinition
+    ) {
       return true;
     }
 

--- a/packages/oxlint/src/__tests__/no-variable-construct-id.test.ts
+++ b/packages/oxlint/src/__tests__/no-variable-construct-id.test.ts
@@ -231,6 +231,39 @@ ruleTester.run("no-variable-construct-id", noVariableConstructId, {
           super(scope, id);
         }
       }
+      const createResource = function (scope: Construct, id: string) {
+        new TargetConstruct(scope, id);
+      };
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const myFunction = function (id: string, num: number) {
+            return new TargetConstruct(this, id + num);
+          };
+          myFunction('id', 1);
+          myFunction('id', 2);
+        }
+      }
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
       class NotAConstruct {
         create(scope: Construct, id: string) {
           new TargetConstruct(scope, id);

--- a/packages/oxlint/src/rules/no-variable-construct-id.ts
+++ b/packages/oxlint/src/rules/no-variable-construct-id.ts
@@ -78,7 +78,7 @@ const validateConstructId = (node: ESTree.NewExpression, context: RuleContext) =
 
 /**
  * Check if construct ID validation should be skipped for a node.
- * Skip if it is inside a loop statement, non-constructor method, or arrow function.
+ * Skip if it is inside a loop statement, non-constructor method, or function other than a constructor.
  */
 const shouldSkipIdValidation = (node: ESTree.Node): boolean => {
   let current = node.parent;
@@ -107,6 +107,15 @@ const shouldSkipIdValidation = (node: ESTree.Node): boolean => {
 
     // Constructs in standalone functions are intended to be called multiple times
     if (current.type === AST_NODE_TYPES.FunctionDeclaration) {
+      return true;
+    }
+
+    // Constructs in function expressions are also intended to be called multiple times.
+    // A constructor body is a FunctionExpression under MethodDefinition and must stay validated.
+    if (
+      current.type === AST_NODE_TYPES.FunctionExpression &&
+      current.parent?.type !== AST_NODE_TYPES.MethodDefinition
+    ) {
       return true;
     }
 


### PR DESCRIPTION
### Issue # (if applicable)

Closes #546.

### Reason for this change

`no-variable-construct-id` reported construct IDs inside function expressions, while the semantically identical function declarations and arrow functions are documented and implemented as not flagged.

### Description of changes

Skip validation inside function expressions in both plugins, except constructor bodies (a constructor body is a `FunctionExpression` under `MethodDefinition`, and must stay validated).

### Description of how you validated changes

- Added valid cases (standalone function expression / function expression inside a constructor) to both plugins' RuleTester suites; `vp check` and `vp test --run` (496/496) pass.
- Confirmed with the issue repro that the false positive disappears and the in-constructor report remains, identically on both plugins.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_