### PR TITLE
fix: report quoted property keys in no-mutable-property-of-props-interface

### DIFF
--- a/packages/eslint/src/__tests__/no-mutable-property-of-props-interface.test.ts
+++ b/packages/eslint/src/__tests__/no-mutable-property-of-props-interface.test.ts
@@ -41,6 +41,15 @@ ruleTester.run("no-mutable-property-of-props-interface", noMutablePropertyOfProp
         }
       `,
     },
+    // WHEN: Quoted property keys are readonly
+    {
+      code: `
+        interface QuotedKeyProps {
+          readonly "bucket-name": string;
+          readonly "table-arn"?: string;
+        }
+      `,
+    },
   ],
   invalid: [
     // WHEN: readonly is not set
@@ -90,6 +99,25 @@ ruleTester.run("no-mutable-property-of-props-interface", noMutablePropertyOfProp
         interface ConfigProps {
           readonly name?: string;
           readonly age?: number;
+        }
+      `,
+      errors: [
+        { messageId: "invalidPropertyOfPropsInterface" },
+        { messageId: "invalidPropertyOfPropsInterface" },
+      ],
+    },
+    // WHEN: Quoted property keys do not have readonly
+    {
+      code: `
+        interface QuotedKeyProps {
+          "bucket-name": string;
+          "table-arn"?: string;
+        }
+      `,
+      output: `
+        interface QuotedKeyProps {
+          readonly "bucket-name": string;
+          readonly "table-arn"?: string;
         }
       `,
       errors: [

--- a/packages/eslint/src/rules/no-mutable-property-of-props-interface.ts
+++ b/packages/eslint/src/rules/no-mutable-property-of-props-interface.ts
@@ -32,21 +32,29 @@ export const noMutablePropertyOfPropsInterface = createRule({
 
         for (const property of node.body.body) {
           // NOTE: check property signature
-          if (
-            property.type !== AST_NODE_TYPES.TSPropertySignature ||
-            property.key.type !== AST_NODE_TYPES.Identifier
-          ) {
-            continue;
-          }
+          if (property.type !== AST_NODE_TYPES.TSPropertySignature) continue;
 
           // NOTE: Skip if already readonly
           if (property.readonly) continue;
+
+          // NOTE: computed keys cannot be resolved statically, so they are skipped
+          let propertyName: string;
+          if (property.key.type === AST_NODE_TYPES.Identifier) {
+            propertyName = property.key.name;
+          } else if (
+            property.key.type === AST_NODE_TYPES.Literal &&
+            (typeof property.key.value === "string" || typeof property.key.value === "number")
+          ) {
+            propertyName = String(property.key.value);
+          } else {
+            continue;
+          }
 
           context.report({
             node: property,
             messageId: "invalidPropertyOfPropsInterface",
             data: {
-              propertyName: property.key.name,
+              propertyName,
             },
             fix: (fixer) => {
               const propertyText = sourceCode.getText(property);

--- a/packages/eslint/src/rules/no-mutable-property-of-props-interface.ts
+++ b/packages/eslint/src/rules/no-mutable-property-of-props-interface.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 
 import { createRule } from "../shared/create-rule";
 
@@ -38,17 +38,8 @@ export const noMutablePropertyOfPropsInterface = createRule({
           if (property.readonly) continue;
 
           // NOTE: computed keys cannot be resolved statically, so they are skipped
-          let propertyName: string;
-          if (property.key.type === AST_NODE_TYPES.Identifier) {
-            propertyName = property.key.name;
-          } else if (
-            property.key.type === AST_NODE_TYPES.Literal &&
-            (typeof property.key.value === "string" || typeof property.key.value === "number")
-          ) {
-            propertyName = String(property.key.value);
-          } else {
-            continue;
-          }
+          const propertyName = findStaticPropertyName(property.key);
+          if (propertyName === null) continue;
 
           context.report({
             node: property,
@@ -66,3 +57,19 @@ export const noMutablePropertyOfPropsInterface = createRule({
     };
   },
 });
+
+/**
+ * Find the static name of a property key
+ * @param key - The key of a property signature
+ * @returns The property name, or null for keys that cannot be resolved statically
+ */
+const findStaticPropertyName = (key: TSESTree.TSPropertySignature["key"]): string | null => {
+  if (key.type === AST_NODE_TYPES.Identifier) return key.name;
+  if (
+    key.type === AST_NODE_TYPES.Literal &&
+    (typeof key.value === "string" || typeof key.value === "number")
+  ) {
+    return String(key.value);
+  }
+  return null;
+};

--- a/packages/oxlint/src/__tests__/no-mutable-property-of-props-interface.test.ts
+++ b/packages/oxlint/src/__tests__/no-mutable-property-of-props-interface.test.ts
@@ -35,6 +35,15 @@ ruleTester.run("no-mutable-property-of-props-interface", noMutablePropertyOfProp
         }
       `,
     },
+    // WHEN: Quoted property keys are readonly
+    {
+      code: `
+        interface QuotedKeyProps {
+          readonly "bucket-name": string;
+          readonly "table-arn"?: string;
+        }
+      `,
+    },
   ],
   invalid: [
     // WHEN: readonly is not set
@@ -84,6 +93,25 @@ ruleTester.run("no-mutable-property-of-props-interface", noMutablePropertyOfProp
         interface ConfigProps {
           readonly name?: string;
           readonly age?: number;
+        }
+      `,
+      errors: [
+        { messageId: "invalidPropertyOfPropsInterface" },
+        { messageId: "invalidPropertyOfPropsInterface" },
+      ],
+    },
+    // WHEN: Quoted property keys do not have readonly
+    {
+      code: `
+        interface QuotedKeyProps {
+          "bucket-name": string;
+          "table-arn"?: string;
+        }
+      `,
+      output: `
+        interface QuotedKeyProps {
+          readonly "bucket-name": string;
+          readonly "table-arn"?: string;
         }
       `,
       errors: [

--- a/packages/oxlint/src/rules/no-mutable-property-of-props-interface.ts
+++ b/packages/oxlint/src/rules/no-mutable-property-of-props-interface.ts
@@ -1,5 +1,6 @@
-import { AST_NODE_TYPES } from "corsa-oxlint";
 import type { ESTree } from "corsa-oxlint";
+
+import { AST_NODE_TYPES } from "corsa-oxlint";
 
 import { createRule } from "../shared/create-rule";
 

--- a/packages/oxlint/src/rules/no-mutable-property-of-props-interface.ts
+++ b/packages/oxlint/src/rules/no-mutable-property-of-props-interface.ts
@@ -30,21 +30,29 @@ export const noMutablePropertyOfPropsInterface = createRule({
 
         for (const property of node.body.body) {
           // NOTE: check property signature
-          if (
-            property.type !== AST_NODE_TYPES.TSPropertySignature ||
-            property.key.type !== AST_NODE_TYPES.Identifier
-          ) {
-            continue;
-          }
+          if (property.type !== AST_NODE_TYPES.TSPropertySignature) continue;
 
           // NOTE: Skip if already readonly
           if (property.readonly) continue;
+
+          // NOTE: computed keys cannot be resolved statically, so they are skipped
+          let propertyName: string;
+          if (property.key.type === AST_NODE_TYPES.Identifier) {
+            propertyName = property.key.name;
+          } else if (
+            property.key.type === AST_NODE_TYPES.Literal &&
+            (typeof property.key.value === "string" || typeof property.key.value === "number")
+          ) {
+            propertyName = String(property.key.value);
+          } else {
+            continue;
+          }
 
           context.report({
             node: property,
             messageId: "invalidPropertyOfPropsInterface",
             data: {
-              propertyName: property.key.name,
+              propertyName,
             },
             fix: (fixer) => {
               const propertyText = sourceCode.getText(property);

--- a/packages/oxlint/src/rules/no-mutable-property-of-props-interface.ts
+++ b/packages/oxlint/src/rules/no-mutable-property-of-props-interface.ts
@@ -1,4 +1,5 @@
 import { AST_NODE_TYPES } from "corsa-oxlint";
+import type { ESTree } from "corsa-oxlint";
 
 import { createRule } from "../shared/create-rule";
 
@@ -36,17 +37,8 @@ export const noMutablePropertyOfPropsInterface = createRule({
           if (property.readonly) continue;
 
           // NOTE: computed keys cannot be resolved statically, so they are skipped
-          let propertyName: string;
-          if (property.key.type === AST_NODE_TYPES.Identifier) {
-            propertyName = property.key.name;
-          } else if (
-            property.key.type === AST_NODE_TYPES.Literal &&
-            (typeof property.key.value === "string" || typeof property.key.value === "number")
-          ) {
-            propertyName = String(property.key.value);
-          } else {
-            continue;
-          }
+          const propertyName = findStaticPropertyName(property.key);
+          if (propertyName === null) continue;
 
           context.report({
             node: property,
@@ -64,3 +56,19 @@ export const noMutablePropertyOfPropsInterface = createRule({
     };
   },
 });
+
+/**
+ * Find the static name of a property key
+ * @param key - The key of a property signature
+ * @returns The property name, or null for keys that cannot be resolved statically
+ */
+const findStaticPropertyName = (key: ESTree.TSPropertySignature["key"]): string | null => {
+  if (key.type === AST_NODE_TYPES.Identifier) return key.name;
+  if (
+    key.type === AST_NODE_TYPES.Literal &&
+    (typeof key.value === "string" || typeof key.value === "number")
+  ) {
+    return String(key.value);
+  }
+  return null;
+};


### PR DESCRIPTION
### Issue # (if applicable)

Closes #542.

### Reason for this change

`no-mutable-property-of-props-interface` skipped every property whose key is not a plain identifier, so quoted keys were never checked for `readonly`.

### Description of changes

Validate properties with static string / number literal keys as well, in both plugins. Only the report data (property name extraction) depends on the key type; computed keys remain skipped because they cannot be resolved statically.

### Description of how you validated changes

- Added valid / invalid cases for quoted keys to both plugins' RuleTester suites, including autofix `output` assertions proving the existing fix produces valid code for quoted keys; `vp check` and `vp test --run` (500/500) pass.
- Confirmed with the issue repro that both plugins now report the quoted key identically.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_