### PR TITLE
fix: make no-mutable-public-property-of-construct autofix produce valid code

### DIFF
--- a/packages/eslint/src/__tests__/no-mutable-public-property-of-construct.test.ts
+++ b/packages/eslint/src/__tests__/no-mutable-public-property-of-construct.test.ts
@@ -147,5 +147,37 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           }
         `,
     },
+    // WHEN: public field type annotation contains `:` (object type literal)
+    {
+      code: `
+          class Construct {}
+          class TestClass extends Construct {
+            public config: { a: string; b: number } = { a: "x", b: 1 };
+          }
+        `,
+      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      output: `
+          class Construct {}
+          class TestClass extends Construct {
+            public readonly config: { a: string; b: number } = { a: "x", b: 1 };
+          }
+        `,
+    },
+    // WHEN: public static field is mutable (readonly must follow static)
+    {
+      code: `
+          class Construct {}
+          class TestClass extends Construct {
+            public static defaultName: string = "sample";
+          }
+        `,
+      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      output: `
+          class Construct {}
+          class TestClass extends Construct {
+            public static readonly defaultName: string = "sample";
+          }
+        `,
+    },
   ],
 });

--- a/packages/eslint/src/rules/no-mutable-public-property-of-construct.ts
+++ b/packages/eslint/src/rules/no-mutable-public-property-of-construct.ts
@@ -1,4 +1,4 @@
-import { ESLintUtils, TSESLint } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils, TSESLint } from "@typescript-eslint/utils";
 
 import {
   findPublicPropertiesInClass,
@@ -34,7 +34,6 @@ export const noMutablePublicPropertyOfConstruct = createRule({
 
     return {
       ClassDeclaration(node) {
-        const sourceCode = context.sourceCode;
         const type = parserServices.getTypeAtLocation(node);
         if (!isConstructOrStackType(type)) return;
 
@@ -43,7 +42,6 @@ export const noMutablePublicPropertyOfConstruct = createRule({
           validatePublicProperty({
             publicProperty: property,
             context,
-            sourceCode,
           });
         }
       },
@@ -54,9 +52,8 @@ export const noMutablePublicPropertyOfConstruct = createRule({
 const validatePublicProperty = (args: {
   publicProperty: PublicProperty;
   context: Context;
-  sourceCode: Readonly<TSESLint.SourceCode>;
 }) => {
-  const { publicProperty, context, sourceCode } = args;
+  const { publicProperty, context } = args;
   if (publicProperty.node.readonly) return;
 
   context.report({
@@ -66,14 +63,16 @@ const validatePublicProperty = (args: {
       propertyName: publicProperty.name,
     },
     fix: (fixer) => {
-      const accessibility = publicProperty.node.accessibility ? "public " : "";
-      const paramText = sourceCode.getText(publicProperty.node);
-      const [key, value] = paramText.split(":");
-      const replacedKey = key.startsWith("public ") ? key.replace("public ", "") : key;
-      return fixer.replaceText(
-        publicProperty.node,
-        `${accessibility}readonly ${replacedKey}:${value}`,
-      );
+      // Insert `readonly ` immediately before the property key so the
+      // surrounding text (type annotations, initializers, other modifiers)
+      // stays byte-identical. TS modifier order is
+      // accessibility -> static -> override -> readonly, so inserting right
+      // before the key always yields a legal position.
+      const anchor =
+        publicProperty.node.type === AST_NODE_TYPES.TSParameterProperty
+          ? publicProperty.node.parameter
+          : publicProperty.node.key;
+      return fixer.insertTextBefore(anchor, "readonly ");
     },
   });
 };

--- a/packages/eslint/src/rules/no-mutable-public-property-of-construct.ts
+++ b/packages/eslint/src/rules/no-mutable-public-property-of-construct.ts
@@ -49,10 +49,7 @@ export const noMutablePublicPropertyOfConstruct = createRule({
   },
 });
 
-const validatePublicProperty = (args: {
-  publicProperty: PublicProperty;
-  context: Context;
-}) => {
+const validatePublicProperty = (args: { publicProperty: PublicProperty; context: Context }) => {
   const { publicProperty, context } = args;
   if (publicProperty.node.readonly) return;
 

--- a/packages/eslint/src/rules/no-mutable-public-property-of-construct.ts
+++ b/packages/eslint/src/rules/no-mutable-public-property-of-construct.ts
@@ -63,11 +63,9 @@ const validatePublicProperty = (args: {
       propertyName: publicProperty.name,
     },
     fix: (fixer) => {
-      // Insert `readonly ` immediately before the property key so the
-      // surrounding text (type annotations, initializers, other modifiers)
-      // stays byte-identical. TS modifier order is
-      // accessibility -> static -> override -> readonly, so inserting right
-      // before the key always yields a legal position.
+      // NOTE: TS modifier order is accessibility -> static -> override -> readonly,
+      // so inserting right before the key is always a legal position
+
       const anchor =
         publicProperty.node.type === AST_NODE_TYPES.TSParameterProperty
           ? publicProperty.node.parameter

--- a/packages/oxlint/src/__tests__/no-mutable-public-property-of-construct.test.ts
+++ b/packages/oxlint/src/__tests__/no-mutable-public-property-of-construct.test.ts
@@ -132,5 +132,35 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           }
         `,
     },
+    {
+      code: `
+          class Construct {}
+          class TestClass extends Construct {
+            public config: { a: string; b: number } = { a: "x", b: 1 };
+          }
+        `,
+      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      output: `
+          class Construct {}
+          class TestClass extends Construct {
+            public readonly config: { a: string; b: number } = { a: "x", b: 1 };
+          }
+        `,
+    },
+    {
+      code: `
+          class Construct {}
+          class TestClass extends Construct {
+            public static defaultName: string = "sample";
+          }
+        `,
+      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      output: `
+          class Construct {}
+          class TestClass extends Construct {
+            public static readonly defaultName: string = "sample";
+          }
+        `,
+    },
   ],
 });

--- a/packages/oxlint/src/rules/no-mutable-public-property-of-construct.ts
+++ b/packages/oxlint/src/rules/no-mutable-public-property-of-construct.ts
@@ -63,11 +63,9 @@ const validatePublicProperty = (args: {
       propertyName: publicProperty.name,
     },
     fix: (fixer) => {
-      // Insert `readonly ` immediately before the property key so the
-      // surrounding text (type annotations, initializers, other modifiers)
-      // stays byte-identical. TS modifier order is
-      // accessibility -> static -> override -> readonly, so inserting right
-      // before the key always yields a legal position.
+      // NOTE: TS modifier order is accessibility -> static -> override -> readonly,
+      // so inserting right before the key is always a legal position
+
       const anchor =
         publicProperty.node.type === AST_NODE_TYPES.TSParameterProperty
           ? publicProperty.node.parameter

--- a/packages/oxlint/src/rules/no-mutable-public-property-of-construct.ts
+++ b/packages/oxlint/src/rules/no-mutable-public-property-of-construct.ts
@@ -1,6 +1,6 @@
 import type { RuleContext } from "corsa-oxlint";
 
-import { ESLintUtils } from "corsa-oxlint";
+import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import {
   findPublicPropertiesInClass,
@@ -8,8 +8,6 @@ import {
 } from "../core/ast-node/finder/public-property";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { createRule } from "../shared/create-rule";
-
-type SourceCode = RuleContext["sourceCode"];
 
 /**
  * Disallow mutable public properties of Construct
@@ -36,7 +34,6 @@ export const noMutablePublicPropertyOfConstruct = createRule({
 
     return {
       ClassDeclaration(node) {
-        const sourceCode = context.sourceCode;
         const type = parserServices.getTypeAtLocation(node);
         if (!isConstructOrStackType(type, checker)) return;
 
@@ -45,7 +42,6 @@ export const noMutablePublicPropertyOfConstruct = createRule({
           validatePublicProperty({
             publicProperty: property,
             context,
-            sourceCode,
           });
         }
       },
@@ -56,9 +52,8 @@ export const noMutablePublicPropertyOfConstruct = createRule({
 const validatePublicProperty = (args: {
   publicProperty: PublicProperty;
   context: RuleContext;
-  sourceCode: SourceCode;
 }) => {
-  const { publicProperty, context, sourceCode } = args;
+  const { publicProperty, context } = args;
   if (publicProperty.node.readonly) return;
 
   context.report({
@@ -68,14 +63,16 @@ const validatePublicProperty = (args: {
       propertyName: publicProperty.name,
     },
     fix: (fixer) => {
-      const accessibility = publicProperty.node.accessibility ? "public " : "";
-      const paramText = sourceCode.getText(publicProperty.node);
-      const [key, value] = paramText.split(":");
-      const replacedKey = key.startsWith("public ") ? key.replace("public ", "") : key;
-      return fixer.replaceText(
-        publicProperty.node,
-        `${accessibility}readonly ${replacedKey}:${value}`,
-      );
+      // Insert `readonly ` immediately before the property key so the
+      // surrounding text (type annotations, initializers, other modifiers)
+      // stays byte-identical. TS modifier order is
+      // accessibility -> static -> override -> readonly, so inserting right
+      // before the key always yields a legal position.
+      const anchor =
+        publicProperty.node.type === AST_NODE_TYPES.TSParameterProperty
+          ? publicProperty.node.parameter
+          : publicProperty.node.key;
+      return fixer.insertTextBefore(anchor, "readonly ");
     },
   });
 };

--- a/packages/oxlint/src/rules/no-mutable-public-property-of-construct.ts
+++ b/packages/oxlint/src/rules/no-mutable-public-property-of-construct.ts
@@ -49,10 +49,7 @@ export const noMutablePublicPropertyOfConstruct = createRule({
   },
 });
 
-const validatePublicProperty = (args: {
-  publicProperty: PublicProperty;
-  context: RuleContext;
-}) => {
+const validatePublicProperty = (args: { publicProperty: PublicProperty; context: RuleContext }) => {
   const { publicProperty, context } = args;
   if (publicProperty.node.readonly) return;
 


### PR DESCRIPTION
### Issue # (if applicable)

Closes #540.

### Reason for this change

The autofix of `no-mutable-public-property-of-construct` rebuilt the property text by splitting on `":"`, which truncated type annotations containing `:` into syntactically invalid code, and inserted `readonly` before `static`, producing an illegal modifier order.

### Description of changes

Replace the text reassembly with a single `insertTextBefore` of `readonly ` at the property key (or the parameter of a parameter property) in both plugins. Since the TS modifier order ends with `readonly`, inserting right before the key is always a legal position and the surrounding text is preserved as-is.

### Description of how you validated changes

- Added invalid cases with autofix `output` assertions for both bug patterns (object-type-literal annotation, static property) to both plugins' RuleTester suites.
- `vp check` and `vp test --run` (500/500) pass; all existing `output` expectations remained valid unchanged.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_