### PR TITLE
fix: segment-based private directory matching in no-import-private

### DIFF
--- a/packages/eslint/src/__tests__/no-import-private.test.ts
+++ b/packages/eslint/src/__tests__/no-import-private.test.ts
@@ -30,6 +30,21 @@ ruleTester.run("no-import-private", noImportPrivate, {
       code: 'import { sample } from "./private/c.ts";',
       filename: "src/sampleB/a.ts",
     },
+    {
+      // WHEN: A directory whose name only starts with `private` is not a `private` dir
+      code: 'import { helper } from "../shared/private-utils/helper";',
+      filename: "src/moduleA/from-private-utils.ts",
+    },
+    {
+      // WHEN: A file inside a `private` subtree can import from its own child `private` dir
+      code: 'import { y } from "./private/y";',
+      filename: "src/lib/private/helper/x.ts",
+    },
+    {
+      // WHEN: Bare specifiers are not resolved as filesystem paths
+      code: 'import { x } from "@myorg/private-utils";',
+      filename: "src/moduleA/a.ts",
+    },
   ],
   invalid: [
     // WHEN: Importing modules in a private directory at a different level is not allowed

--- a/packages/eslint/src/__tests__/no-import-private.test.ts
+++ b/packages/eslint/src/__tests__/no-import-private.test.ts
@@ -45,6 +45,16 @@ ruleTester.run("no-import-private", noImportPrivate, {
       code: 'import { x } from "@myorg/private-utils";',
       filename: "src/moduleA/a.ts",
     },
+    {
+      // WHEN: A file inside a `private` dir imports its own sibling module
+      code: 'import { b } from "./b";',
+      filename: "src/lib/private/a.ts",
+    },
+    {
+      // WHEN: A file inside a `private` subtree imports another module in the same subtree
+      code: 'import { shared } from "../shared";',
+      filename: "src/lib/private/helper/x.ts",
+    },
   ],
   invalid: [
     // WHEN: Importing modules in a private directory at a different level is not allowed

--- a/packages/eslint/src/rules/no-import-private.ts
+++ b/packages/eslint/src/rules/no-import-private.ts
@@ -23,18 +23,22 @@ export const noImportPrivate: Rule.RuleModule = {
     return {
       ImportDeclaration(node) {
         const importPath = node.source.value?.toString() ?? "";
-        const currentFilePath = context.filename;
-        const currentDirPath = path.dirname(currentFilePath);
+        // Only relative imports can address a `private` directory on disk.
+        // Bare specifiers like `@scope/private-utils` must not be resolved as paths.
+        if (!importPath.startsWith("./") && !importPath.startsWith("../")) return;
 
-        if (!importPath.includes("/private")) return;
+        const currentDirPath = path.dirname(context.filename);
         const absoluteCurrentDirPath = path.resolve(currentDirPath);
         const absoluteImportPath = path.resolve(currentDirPath, importPath);
 
-        // NOTE: Get the directory from the import path up to the private directory
-        const importDirBeforePrivate = absoluteImportPath.split("/private")[0];
+        const importSegments = getDirSegments(absoluteImportPath);
+        // Match the deepest exact `private` segment so that a `private` subtree
+        // can still import from its own child `private` directory.
+        const lastPrivateIndex = importSegments.lastIndexOf("private");
+        if (lastPrivateIndex === -1) return;
 
+        const importDirSegments = importSegments.slice(0, lastPrivateIndex);
         const currentDirSegments = getDirSegments(absoluteCurrentDirPath);
-        const importDirSegments = getDirSegments(importDirBeforePrivate);
         if (
           currentDirSegments.length !== importDirSegments.length ||
           currentDirSegments.some((segment, index) => segment !== importDirSegments[index])
@@ -47,7 +51,7 @@ export const noImportPrivate: Rule.RuleModule = {
 };
 
 /**
- * Split the directory path into segments (split at `/`)
+ * Split the directory path into segments using the platform separator.
  * @param dirPath - The directory path to split
  * @returns The segments of the directory path
  */

--- a/packages/eslint/src/rules/no-import-private.ts
+++ b/packages/eslint/src/rules/no-import-private.ts
@@ -39,6 +39,13 @@ export const noImportPrivate: Rule.RuleModule = {
 
         const importDirSegments = importSegments.slice(0, lastPrivateIndex);
         const currentDirSegments = getDirSegments(absoluteCurrentDirPath);
+
+        // NOTE: an importer inside the private subtree itself is not crossing its boundary
+        const privateRootSegments = importSegments.slice(0, lastPrivateIndex + 1);
+        if (privateRootSegments.every((segment, index) => segment === currentDirSegments[index])) {
+          return;
+        }
+
         if (
           currentDirSegments.length !== importDirSegments.length ||
           currentDirSegments.some((segment, index) => segment !== importDirSegments[index])

--- a/packages/oxlint/src/__tests__/no-import-private.test.ts
+++ b/packages/oxlint/src/__tests__/no-import-private.test.ts
@@ -30,6 +30,21 @@ ruleTester.run("no-import-private", noImportPrivate, {
       code: 'import { sample } from "./private/c.ts";',
       filename: "src/sampleB/a.ts",
     },
+    {
+      // WHEN: A directory whose name only starts with `private` is not a `private` dir
+      code: 'import { helper } from "../shared/private-utils/helper";',
+      filename: "src/moduleA/from-private-utils.ts",
+    },
+    {
+      // WHEN: A file inside a `private` subtree can import from its own child `private` dir
+      code: 'import { y } from "./private/y";',
+      filename: "src/lib/private/helper/x.ts",
+    },
+    {
+      // WHEN: Bare specifiers are not resolved as filesystem paths
+      code: 'import { x } from "@myorg/private-utils";',
+      filename: "src/moduleA/a.ts",
+    },
   ],
   invalid: [
     // WHEN: Importing modules in a private directory at a different level is not allowed

--- a/packages/oxlint/src/__tests__/no-import-private.test.ts
+++ b/packages/oxlint/src/__tests__/no-import-private.test.ts
@@ -45,6 +45,16 @@ ruleTester.run("no-import-private", noImportPrivate, {
       code: 'import { x } from "@myorg/private-utils";',
       filename: "src/moduleA/a.ts",
     },
+    {
+      // WHEN: A file inside a `private` dir imports its own sibling module
+      code: 'import { b } from "./b";',
+      filename: "src/lib/private/a.ts",
+    },
+    {
+      // WHEN: A file inside a `private` subtree imports another module in the same subtree
+      code: 'import { shared } from "../shared";',
+      filename: "src/lib/private/helper/x.ts",
+    },
   ],
   invalid: [
     // WHEN: Importing modules in a private directory at a different level is not allowed

--- a/packages/oxlint/src/rules/no-import-private.ts
+++ b/packages/oxlint/src/rules/no-import-private.ts
@@ -39,6 +39,13 @@ export const noImportPrivate = createRule({
 
         const importDirSegments = importSegments.slice(0, lastPrivateIndex);
         const currentDirSegments = getDirSegments(absoluteCurrentDirPath);
+
+        // NOTE: an importer inside the private subtree itself is not crossing its boundary
+        const privateRootSegments = importSegments.slice(0, lastPrivateIndex + 1);
+        if (privateRootSegments.every((segment, index) => segment === currentDirSegments[index])) {
+          return;
+        }
+
         if (
           currentDirSegments.length !== importDirSegments.length ||
           currentDirSegments.some((segment, index) => segment !== importDirSegments[index])

--- a/packages/oxlint/src/rules/no-import-private.ts
+++ b/packages/oxlint/src/rules/no-import-private.ts
@@ -23,18 +23,22 @@ export const noImportPrivate = createRule({
     return {
       ImportDeclaration(node) {
         const importPath = node.source.value?.toString() ?? "";
-        const currentFilePath = context.filename;
-        const currentDirPath = path.dirname(currentFilePath);
+        // Only relative imports can address a `private` directory on disk.
+        // Bare specifiers like `@scope/private-utils` must not be resolved as paths.
+        if (!importPath.startsWith("./") && !importPath.startsWith("../")) return;
 
-        if (!importPath.includes("/private")) return;
+        const currentDirPath = path.dirname(context.filename);
         const absoluteCurrentDirPath = path.resolve(currentDirPath);
         const absoluteImportPath = path.resolve(currentDirPath, importPath);
 
-        // NOTE: Get the directory from the import path up to the private directory
-        const importDirBeforePrivate = absoluteImportPath.split("/private")[0];
+        const importSegments = getDirSegments(absoluteImportPath);
+        // Match the deepest exact `private` segment so that a `private` subtree
+        // can still import from its own child `private` directory.
+        const lastPrivateIndex = importSegments.lastIndexOf("private");
+        if (lastPrivateIndex === -1) return;
 
+        const importDirSegments = importSegments.slice(0, lastPrivateIndex);
         const currentDirSegments = getDirSegments(absoluteCurrentDirPath);
-        const importDirSegments = getDirSegments(importDirBeforePrivate);
         if (
           currentDirSegments.length !== importDirSegments.length ||
           currentDirSegments.some((segment, index) => segment !== importDirSegments[index])
@@ -47,7 +51,7 @@ export const noImportPrivate = createRule({
 });
 
 /**
- * Split the directory path into segments (split at `path.sep`).
+ * Split the directory path into segments using the platform separator.
  */
 const getDirSegments = (dirPath: string): string[] => {
   return dirPath.split(path.sep).filter((segment) => segment !== "");


### PR DESCRIPTION
### Issue # (if applicable)

Closes #544.

### Reason for this change

`no-import-private` matched the `private` directory with plain `"/private"` substring / split operations, which caused false positives for directories that merely start with `private` (e.g. `private-utils`), broke same-level imports inside a `private` subtree, and reported every import on Windows because the hardcoded `/` never matches `\`-separated resolved paths.

### Description of changes

Rewrite the check to be segment-based in both plugins, keeping the documented semantics (a `private` dir may only be imported from its parent directory):

- Non-relative specifiers are ignored (bare specifiers must not be resolved as file paths)
- The resolved import path is split by `path.sep` and the deepest segment exactly equal to `private` is the boundary; its parent segments must equal the importing directory
- Importers located inside the private subtree itself are not crossing its boundary (keeps sibling / internal imports allowed, as before)

### Description of how you validated changes

- Added valid cases to both plugins' RuleTester suites: `private-utils` sibling dir, child `private` inside a `private` subtree, bare specifier, and internal imports from inside a `private` dir; `vp check` and `vp test --run` (506/506) pass.
- Windows behavior relies on `path.sep`-based segmentation; the windows-integration CI job runs the suite on Windows.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_