### PR TITLE
fix: resolve inherited constructors via construct signatures in eslint plugin

### DIFF
--- a/packages/eslint/src/__tests__/no-construct-stack-suffix.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-stack-suffix.test.ts
@@ -104,6 +104,19 @@ ruleTester.run("no-construct-stack-suffix", noConstructStackSuffix, {
       new SampleConstruct({ name: "sample" }, "SampleConstruct");`,
       errors: [{ messageId: "invalidConstructId" }],
     },
+    // WHEN: construct id has "Construct" suffix, and the instantiated class inherits its constructor
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class InheritedSample extends SampleConstruct {}
+      new InheritedSample({ name: "sample" }, "SampleConstruct");`,
+      errors: [{ messageId: "invalidConstructId" }],
+    },
     // WHEN: stack id has "Stack" suffix, and extends Stack
     {
       code: `

--- a/packages/eslint/src/__tests__/no-variable-construct-id.test.ts
+++ b/packages/eslint/src/__tests__/no-variable-construct-id.test.ts
@@ -314,6 +314,25 @@ ruleTester.run("no-variable-construct-id", noVariableConstructId, {
       `,
       errors: [{ messageId: "invalidConstructId" }],
     },
+    // WHEN: id is variable and the instantiated class inherits its constructor
+    {
+      code: `
+      class Construct {}
+      class TargetConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class InheritedConstruct extends TargetConstruct {}
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new InheritedConstruct(this, id);
+        }
+      }
+      `,
+      errors: [{ messageId: "invalidConstructId" }],
+    },
     {
       code: `
       class Construct {}

--- a/packages/eslint/src/__tests__/pascal-case-construct-id.test.ts
+++ b/packages/eslint/src/__tests__/pascal-case-construct-id.test.ts
@@ -132,5 +132,27 @@ ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
       }
       const test = new TestClass('test', 'InvalidId');`,
     },
+    // WHEN: id is snake_case and the instantiated class inherits its constructor
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class InheritedClass extends TestClass {}
+      const test = new InheritedClass("test", "invalid_id");`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class InheritedClass extends TestClass {}
+      const test = new InheritedClass("test", "InvalidId");`,
+    },
   ],
 });

--- a/packages/eslint/src/__tests__/prevent-construct-id-collision.test.ts
+++ b/packages/eslint/src/__tests__/prevent-construct-id-collision.test.ts
@@ -279,6 +279,26 @@ ruleTester.run("prevent-construct-id-collision", preventConstructIdCollision, {
       `,
       errors: [{ messageId: "preventConstructIdCollision", data: { constructId: "Bucket" } }],
     },
+    // WHEN: Literal ID inside forEach and the instantiated class inherits its constructor
+    {
+      name: "literal ID in forEach with an inherited constructor is invalid",
+      code: `
+      class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class InheritedBucket extends Bucket {}
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          [1, 2, 3].forEach(() => new InheritedBucket(this, "Bucket"));
+        }
+      }
+      `,
+      errors: [{ messageId: "preventConstructIdCollision", data: { constructId: "Bucket" } }],
+    },
     // WHEN: Literal ID inside map
     {
       name: "literal ID in map is invalid",

--- a/packages/eslint/src/__tests__/require-passing-this.test.ts
+++ b/packages/eslint/src/__tests__/require-passing-this.test.ts
@@ -162,6 +162,40 @@ ruleTester.run("require-passing-this", requirePassingThis, {
       }
       `,
     },
+    // WHEN: instantiated class inherits its constructor from a parent Construct
+    {
+      code: `
+      class Construct {}
+      class Target extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Inherited extends Target {}
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new Inherited(scope, "X");
+        }
+      }
+      `,
+      errors: [{ messageId: "missingPassingThis" }],
+      output: `
+      class Construct {}
+      class Target extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Inherited extends Target {}
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new Inherited(this, "X");
+        }
+      }
+      `,
+    },
     // WHEN: allowNonThisAndDisallowScope is false and not passing `this`
     {
       options: [{ allowNonThisAndDisallowScope: false }],

--- a/packages/eslint/src/__tests__/require-passing-this.test.ts
+++ b/packages/eslint/src/__tests__/require-passing-this.test.ts
@@ -128,6 +128,28 @@ ruleTester.run("require-passing-this", requirePassingThis, {
       `,
       options: [{ allowNonThisAndDisallowScope: true }],
     },
+    // WHEN: subclass redeclares a constructor that does not follow (scope, id)
+    {
+      code: `
+      class Construct {}
+      class Target extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Wrapped extends Target {
+        constructor(config: { scope: Construct }) {
+          super(config.scope, "Fixed");
+        }
+      }
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new Wrapped({ scope });
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     // WHEN: passing 'scope' variable

--- a/packages/eslint/src/core/ts-type/finder/constructor-property-name.ts
+++ b/packages/eslint/src/core/ts-type/finder/constructor-property-name.ts
@@ -1,18 +1,17 @@
-import { isClassDeclaration, isConstructorDeclaration, Type } from "typescript";
+import { SignatureKind, Type, TypeChecker } from "typescript";
 
 /**
  * Parses type to get the property names of the class constructor.
+ * Resolves via construct signatures so that inherited constructors are honored.
  * @returns The property names of the class constructor.
  */
-export const findConstructorPropertyNames = (type: Type): string[] => {
-  const declarations = type.symbol?.declarations;
-  if (!declarations?.length) return [];
+export const findConstructorPropertyNames = (
+  type: Type | undefined,
+  checker: TypeChecker,
+): string[] => {
+  if (!type) return [];
+  const signature = checker.getSignaturesOfType(type, SignatureKind.Construct)[0];
+  if (!signature) return [];
 
-  const classDeclaration = declarations[0];
-  if (!isClassDeclaration(classDeclaration)) return [];
-
-  const constructor = classDeclaration.members.find((member) => isConstructorDeclaration(member));
-  if (!constructor?.parameters.length) return [];
-
-  return constructor.parameters.map((param) => param.name.getText());
+  return signature.getParameters().map((symbol) => symbol.name);
 };

--- a/packages/eslint/src/rules/no-construct-stack-suffix.ts
+++ b/packages/eslint/src/rules/no-construct-stack-suffix.ts
@@ -57,6 +57,7 @@ export const noConstructStackSuffix = createRule({
   defaultOptions: [defaultOption],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
 
     return {
       NewExpression(node) {
@@ -65,7 +66,8 @@ export const noConstructStackSuffix = createRule({
           return;
         }
 
-        const constructorPropertyNames = findConstructorPropertyNames(type);
+        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[1] !== "id") return;
 
         validateConstructId(node, context);

--- a/packages/eslint/src/rules/no-variable-construct-id.ts
+++ b/packages/eslint/src/rules/no-variable-construct-id.ts
@@ -28,6 +28,7 @@ export const noVariableConstructId = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
@@ -41,7 +42,8 @@ export const noVariableConstructId = createRule({
           : undefined;
         if (enclosingClassType && !isConstructOrStackType(enclosingClassType)) return;
 
-        const constructorPropertyNames = findConstructorPropertyNames(type);
+        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[1] !== "id") return;
 
         validateConstructId(node, context);

--- a/packages/eslint/src/rules/pascal-case-construct-id.ts
+++ b/packages/eslint/src/rules/pascal-case-construct-id.ts
@@ -36,6 +36,7 @@ export const pascalCaseConstructId = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
@@ -43,7 +44,8 @@ export const pascalCaseConstructId = createRule({
           return;
         }
 
-        const constructorPropertyNames = findConstructorPropertyNames(type);
+        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[1] !== "id") return;
 
         validateConstructId(node, context);

--- a/packages/eslint/src/rules/prevent-construct-id-collision.ts
+++ b/packages/eslint/src/rules/prevent-construct-id-collision.ts
@@ -25,13 +25,15 @@ export const preventConstructIdCollision = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
 
         if (!isConstructType(type) || node.arguments.length < 2) return;
 
-        const constructorPropertyNames = findConstructorPropertyNames(type);
+        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[1] !== "id") return;
 
         validateConstructIdInLoop(node, context);

--- a/packages/eslint/src/rules/require-passing-this.ts
+++ b/packages/eslint/src/rules/require-passing-this.ts
@@ -49,6 +49,7 @@ export const requirePassingThis = createRule({
   create(context: Context) {
     const options = context.options[0] || defaultOption;
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
@@ -67,7 +68,8 @@ export const requirePassingThis = createRule({
         if (argument.type === AST_NODE_TYPES.ThisExpression) return;
 
         // NOTE: If the first argument is not `scope`, it's valid
-        const constructorPropertyNames = findConstructorPropertyNames(type);
+        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[0] !== "scope") return;
 
         // NOTE: If `allowNonThisAndDisallowScope` is false, require `this` for all cases


### PR DESCRIPTION
### Issue # (if applicable)

Closes #536.

### Reason for this change

eslint-plugin-awscdk resolved constructor parameter names by searching the own members of `type.symbol.declarations[0]`, so classes that inherit their constructor (`class LoggingBucket extends Bucket {}`) returned no names and every rule guarded by `scope` / `id` name checks silently skipped them — diverging from oxlint-plugin-awscdk, which resolves construct signatures through the type checker.

### Description of changes

Rewrite `findConstructorPropertyNames` to resolve the callee's construct signature via `checker.getSignaturesOfType(type, SignatureKind.Construct)`, mirroring the oxlint implementation, and pass the callee type from the five caller rules.

### Description of how you validated changes

- Added an inherited-constructor invalid case (with autofix `output`) to the require-passing-this suite; `vp check` and `vp test --run` (501/501) pass.
- Confirmed with the issue repro that the eslint plugin now reports the inherited-constructor cases for pascal-case-construct-id and require-passing-this, byte-identical to the oxlint plugin's output.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_