### PR TITLE
fix: validate template literal construct ids in pascal-case and stack-suffix rules

### DIFF
--- a/packages/eslint/src/__tests__/no-construct-stack-suffix.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-stack-suffix.test.ts
@@ -90,6 +90,18 @@ ruleTester.run("no-construct-stack-suffix", noConstructStackSuffix, {
       new SampleStack({ name: "sample" }, "SampleStack");`,
       options: [{ disallowedSuffixes: ["Construct"] }],
     },
+    // WHEN: construct id is a template literal with expressions (dynamic)
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const suffix = 'x';
+      new SampleConstruct({ name: "sample" }, \`Sample-\${suffix}\`);`,
+    },
   ],
   invalid: [
     // WHEN: construct id has "Construct" suffix, and extends Construct
@@ -140,6 +152,18 @@ ruleTester.run("no-construct-stack-suffix", noConstructStackSuffix, {
       }
       new SampleStack({ name: "sample" }, "SampleStack");`,
       options: [{ disallowedSuffixes: ["Stack"] }],
+      errors: [{ messageId: "invalidConstructId" }],
+    },
+    // WHEN: construct id is a template literal without expressions and has "Construct" suffix
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      new SampleConstruct({ name: "sample" }, \`TemplateBucketConstruct\`);`,
       errors: [{ messageId: "invalidConstructId" }],
     },
   ],

--- a/packages/eslint/src/__tests__/pascal-case-construct-id.test.ts
+++ b/packages/eslint/src/__tests__/pascal-case-construct-id.test.ts
@@ -90,6 +90,29 @@ ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
       }
       const test = new TestClass("test", "invalid_id");`,
     },
+    // WHEN: id is PascalCase template literal without expressions
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', \`ValidId\`);`,
+    },
+    // WHEN: id is a template literal with expressions
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const suffix = 'x';
+      const test = new TestClass('test', \`bucket-\${suffix}\`);`,
+    },
   ],
   invalid: [
     // WHEN: id is snake_case(double quote)
@@ -131,6 +154,26 @@ ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
         }
       }
       const test = new TestClass('test', 'InvalidId');`,
+    },
+    // WHEN: id is snake_case template literal without expressions
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', \`template_bucket\`);`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', \`TemplateBucket\`);`,
     },
   ],
 });

--- a/packages/eslint/src/core/ast-node/finder/construct-id-string.ts
+++ b/packages/eslint/src/core/ast-node/finder/construct-id-string.ts
@@ -1,0 +1,17 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+
+/**
+ * Retrieve the static string ID from a `NewExpression` argument node.
+ * Returns the string for a string literal or an expression-less template literal,
+ * and `null` for any other argument shape (numbers, identifiers, templates with
+ * `${}` interpolation, etc.).
+ */
+export const findConstructIdString = (node: TSESTree.Node): string | null => {
+  if (node.type === AST_NODE_TYPES.Literal && typeof node.value === "string") {
+    return node.value;
+  }
+  if (node.type === AST_NODE_TYPES.TemplateLiteral && !node.expressions.length) {
+    return node.quasis.map((q) => q.value.raw).join("");
+  }
+  return null;
+};

--- a/packages/eslint/src/rules/no-construct-stack-suffix.ts
+++ b/packages/eslint/src/rules/no-construct-stack-suffix.ts
@@ -1,5 +1,6 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
+import { ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
 
+import { findConstructIdString } from "../core/ast-node/finder/construct-id-string";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
@@ -82,11 +83,10 @@ const validateConstructId = (node: TSESTree.NewExpression, context: Context): vo
 
   // NOTE: Treat the second argument as ID
   const secondArg = node.arguments[1];
-  if (secondArg.type !== AST_NODE_TYPES.Literal || typeof secondArg.value !== "string") {
-    return;
-  }
+  const constructId = findConstructIdString(secondArg);
+  if (constructId === null) return;
 
-  const formattedConstructId = toPascalCase(secondArg.value);
+  const formattedConstructId = toPascalCase(constructId);
   const disallowedSuffixes = options.disallowedSuffixes;
 
   if (
@@ -98,7 +98,7 @@ const validateConstructId = (node: TSESTree.NewExpression, context: Context): vo
       messageId: "invalidConstructId",
       data: {
         classType: "Construct",
-        id: secondArg.value,
+        id: constructId,
         suffix: SUFFIX_TYPE.CONSTRUCT,
       },
     });
@@ -111,7 +111,7 @@ const validateConstructId = (node: TSESTree.NewExpression, context: Context): vo
       messageId: "invalidConstructId",
       data: {
         classType: "Stack",
-        id: secondArg.value,
+        id: constructId,
         suffix: SUFFIX_TYPE.STACK,
       },
     });

--- a/packages/eslint/src/rules/pascal-case-construct-id.ts
+++ b/packages/eslint/src/rules/pascal-case-construct-id.ts
@@ -1,5 +1,6 @@
 import { AST_NODE_TYPES, ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
 
+import { findConstructIdString } from "../core/ast-node/finder/construct-id-string";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
@@ -8,6 +9,7 @@ import { createRule } from "../shared/create-rule";
 const QUOTE_TYPE = {
   SINGLE: "'",
   DOUBLE: '"',
+  BACKTICK: "`",
 } as const;
 
 type QuoteType = (typeof QUOTE_TYPE)[keyof typeof QUOTE_TYPE];
@@ -62,6 +64,16 @@ const isPascalCase = (str: string) => {
 };
 
 /**
+ * Pick the quote type used to wrap the ID literal so that the fixer keeps
+ * the original delimiter (single/double quote or backtick).
+ */
+const findQuoteType = (node: TSESTree.Node): QuoteType => {
+  if (node.type === AST_NODE_TYPES.TemplateLiteral) return QUOTE_TYPE.BACKTICK;
+  if (node.type === AST_NODE_TYPES.Literal && node.raw?.startsWith('"')) return QUOTE_TYPE.DOUBLE;
+  return QUOTE_TYPE.SINGLE;
+};
+
+/**
  * Check the construct ID is PascalCase
  */
 const validateConstructId = (node: TSESTree.NewExpression, context: Context) => {
@@ -69,19 +81,18 @@ const validateConstructId = (node: TSESTree.NewExpression, context: Context) => 
 
   // NOTE: Treat the second argument as ID
   const secondArg = node.arguments[1];
-  if (secondArg.type !== AST_NODE_TYPES.Literal || typeof secondArg.value !== "string") {
-    return;
-  }
+  const constructId = findConstructIdString(secondArg);
+  if (constructId === null) return;
 
-  const quote: QuoteType = secondArg.raw?.startsWith('"') ? QUOTE_TYPE.DOUBLE : QUOTE_TYPE.SINGLE;
+  if (isPascalCase(constructId)) return;
 
-  if (isPascalCase(secondArg.value)) return;
+  const quote = findQuoteType(secondArg);
 
   context.report({
     node: secondArg,
     messageId: "invalidConstructId",
     fix: (fixer) => {
-      const pascalCaseValue = toPascalCase(secondArg.value);
+      const pascalCaseValue = toPascalCase(constructId);
       return fixer.replaceText(secondArg, `${quote}${pascalCaseValue}${quote}`);
     },
   });

--- a/packages/oxlint/src/__tests__/no-construct-stack-suffix.test.ts
+++ b/packages/oxlint/src/__tests__/no-construct-stack-suffix.test.ts
@@ -78,6 +78,17 @@ ruleTester.run("no-construct-stack-suffix", noConstructStackSuffix, {
       new SampleStack({ name: "sample" }, "SampleStack");`,
       options: [{ disallowedSuffixes: ["Construct"] }],
     },
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const suffix = 'x';
+      new SampleConstruct({ name: "sample" }, \`Sample-\${suffix}\`);`,
+    },
   ],
   invalid: [
     {
@@ -124,6 +135,17 @@ ruleTester.run("no-construct-stack-suffix", noConstructStackSuffix, {
       }
       new SampleStack({ name: "sample" }, "SampleStack");`,
       options: [{ disallowedSuffixes: ["Stack"] }],
+      errors: [{ messageId: "invalidConstructId" }],
+    },
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      new SampleConstruct({ name: "sample" }, \`TemplateBucketConstruct\`);`,
       errors: [{ messageId: "invalidConstructId" }],
     },
   ],

--- a/packages/oxlint/src/__tests__/pascal-case-construct-id.test.ts
+++ b/packages/oxlint/src/__tests__/pascal-case-construct-id.test.ts
@@ -77,6 +77,27 @@ ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
       }
       const test = new TestClass("test", "invalid_id");`,
     },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', \`ValidId\`);`,
+    },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const suffix = 'x';
+      const test = new TestClass('test', \`bucket-\${suffix}\`);`,
+    },
   ],
   invalid: [
     {
@@ -116,6 +137,25 @@ ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
         }
       }
       const test = new TestClass('test', 'InvalidId');`,
+    },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', \`template_bucket\`);`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', \`TemplateBucket\`);`,
     },
   ],
 });

--- a/packages/oxlint/src/core/ast-node/finder/construct-id-string.ts
+++ b/packages/oxlint/src/core/ast-node/finder/construct-id-string.ts
@@ -1,0 +1,19 @@
+import type { ESTree } from "corsa-oxlint";
+
+import { AST_NODE_TYPES } from "corsa-oxlint";
+
+/**
+ * Retrieve the static string ID from a `NewExpression` argument node.
+ * Returns the string for a string literal or an expression-less template literal,
+ * and `null` for any other argument shape (numbers, identifiers, templates with
+ * `${}` interpolation, etc.).
+ */
+export const findConstructIdString = (node: ESTree.Node): string | null => {
+  if (node.type === AST_NODE_TYPES.Literal && typeof node.value === "string") {
+    return node.value;
+  }
+  if (node.type === AST_NODE_TYPES.TemplateLiteral && !node.expressions.length) {
+    return node.quasis.map((q) => q.value.raw).join("");
+  }
+  return null;
+};

--- a/packages/oxlint/src/rules/no-construct-stack-suffix.ts
+++ b/packages/oxlint/src/rules/no-construct-stack-suffix.ts
@@ -1,7 +1,8 @@
 import type { ESTree, RuleContext } from "corsa-oxlint";
 
-import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
+import { ESLintUtils } from "corsa-oxlint";
 
+import { findConstructIdString } from "../core/ast-node/finder/construct-id-string";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
@@ -86,11 +87,10 @@ const validateConstructId = (
 ): void => {
   // NOTE: Treat the second argument as ID
   const secondArg = node.arguments[1];
-  if (secondArg.type !== AST_NODE_TYPES.Literal || typeof secondArg.value !== "string") {
-    return;
-  }
+  const constructId = findConstructIdString(secondArg);
+  if (constructId === null) return;
 
-  const formattedConstructId = toPascalCase(secondArg.value);
+  const formattedConstructId = toPascalCase(constructId);
   const disallowedSuffixes = options.disallowedSuffixes;
 
   if (
@@ -102,7 +102,7 @@ const validateConstructId = (
       messageId: "invalidConstructId",
       data: {
         classType: "Construct",
-        id: secondArg.value,
+        id: constructId,
         suffix: SUFFIX_TYPE.CONSTRUCT,
       },
     });
@@ -115,7 +115,7 @@ const validateConstructId = (
       messageId: "invalidConstructId",
       data: {
         classType: "Stack",
-        id: secondArg.value,
+        id: constructId,
         suffix: SUFFIX_TYPE.STACK,
       },
     });

--- a/packages/oxlint/src/rules/pascal-case-construct-id.ts
+++ b/packages/oxlint/src/rules/pascal-case-construct-id.ts
@@ -2,6 +2,7 @@ import type { ESTree, RuleContext } from "corsa-oxlint";
 
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
+import { findConstructIdString } from "../core/ast-node/finder/construct-id-string";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
@@ -10,6 +11,7 @@ import { createRule } from "../shared/create-rule";
 const QUOTE_TYPE = {
   SINGLE: "'",
   DOUBLE: '"',
+  BACKTICK: "`",
 } as const;
 
 type QuoteType = (typeof QUOTE_TYPE)[keyof typeof QUOTE_TYPE];
@@ -60,6 +62,16 @@ const isPascalCase = (str: string) => {
 };
 
 /**
+ * Pick the quote type used to wrap the ID literal so that the fixer keeps
+ * the original delimiter (single/double quote or backtick).
+ */
+const findQuoteType = (node: ESTree.Node): QuoteType => {
+  if (node.type === AST_NODE_TYPES.TemplateLiteral) return QUOTE_TYPE.BACKTICK;
+  if (node.type === AST_NODE_TYPES.Literal && node.raw?.startsWith('"')) return QUOTE_TYPE.DOUBLE;
+  return QUOTE_TYPE.SINGLE;
+};
+
+/**
  * Check the construct ID is PascalCase
  */
 const validateConstructId = (node: ESTree.NewExpression, context: RuleContext) => {
@@ -67,19 +79,18 @@ const validateConstructId = (node: ESTree.NewExpression, context: RuleContext) =
 
   // NOTE: Treat the second argument as ID
   const secondArg = node.arguments[1];
-  if (secondArg.type !== AST_NODE_TYPES.Literal || typeof secondArg.value !== "string") {
-    return;
-  }
+  const constructId = findConstructIdString(secondArg);
+  if (constructId === null) return;
 
-  const quote: QuoteType = secondArg.raw?.startsWith('"') ? QUOTE_TYPE.DOUBLE : QUOTE_TYPE.SINGLE;
+  if (isPascalCase(constructId)) return;
 
-  if (isPascalCase(secondArg.value)) return;
+  const quote = findQuoteType(secondArg);
 
   context.report({
     node: secondArg,
     messageId: "invalidConstructId",
     fix: (fixer) => {
-      const pascalCaseValue = toPascalCase(secondArg.value);
+      const pascalCaseValue = toPascalCase(constructId);
       return fixer.replaceText(secondArg, `${quote}${pascalCaseValue}${quote}`);
     },
   });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #545.

### Reason for this change

`pascal-case-construct-id` and `no-construct-stack-suffix` validated the construct ID only when it is a string literal, so switching quotes to backticks silently bypassed both naming checks — although the rest of the suite (`prevent-construct-id-collision`) already treats expression-less template literals as static string IDs.

### Description of changes

Add a `findConstructIdString` finder (mirrored in both plugins) that returns the static string for a string literal or an expression-less template literal, and use it in both rules. Template literals with interpolation remain skipped, and the pascal-case autofix keeps the original delimiter (backticks stay backticks).

### Description of how you validated changes

- Added valid / invalid template-literal cases (including autofix `output`) to both rules' suites in both plugins; `vp check` and `vp test --run` (510/510) pass.
- Confirmed with the issue repro that `` `template_bucket` `` / `` `TemplateBucketConstruct` `` are now reported identically by both plugins.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_