### PR TITLE
fix: resolve constructor implementation instead of overload signature

### DIFF
--- a/packages/eslint/src/__tests__/construct-constructor-property.test.ts
+++ b/packages/eslint/src/__tests__/construct-constructor-property.test.ts
@@ -236,5 +236,25 @@ ruleTester.run("construct-constructor-property", constructConstructorProperty, {
       `,
       errors: [{ messageId: "invalidConstructorProperty" }],
     },
+    {
+      name: "constructor overload signatures are valid but implementation signature has invalid property names",
+      code: `
+      class Construct {}
+      interface MyConstructProps {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string);
+        constructor(scope: Construct, id: string, props: MyConstructProps);
+        constructor(parent: Construct, name: string, opts?: MyConstructProps) {
+          super(parent, name);
+        }
+      }
+      `,
+      errors: [
+        { messageId: "invalidConstructorProperty" },
+        { messageId: "invalidConstructorProperty" },
+        { messageId: "invalidConstructorProperty" },
+      ],
+    },
   ],
 });

--- a/packages/eslint/src/__tests__/no-unused-props.test.ts
+++ b/packages/eslint/src/__tests__/no-unused-props.test.ts
@@ -507,6 +507,26 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       }
       `,
     },
+    {
+      name: "Constructor with overload signatures: all props are used in the implementation body",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string);
+        constructor(scope: Construct, id: string, props: MyConstructProps);
+        constructor(scope: Construct, id: string, props?: MyConstructProps) {
+          super(scope, id);
+          console.log(props?.bucketName, props?.enableVersioning);
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint/src/__tests__/props-name-convention.test.ts
+++ b/packages/eslint/src/__tests__/props-name-convention.test.ts
@@ -53,6 +53,30 @@ ruleTester.run("props-name-convention", propsNameConvention, {
   ],
   invalid: [
     {
+      // WHEN: constructor has an overload signature and the implementation takes wrongly named props
+      code: `
+        class Construct {}
+        interface Props {
+          readonly bucket?: string;
+        }
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string);
+          constructor(scope: Construct, id: string, props?: Props) {
+            super(scope, id);
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidPropsName",
+          data: {
+            interfaceName: "Props",
+            expectedName: "MyConstructProps",
+          },
+        },
+      ],
+    },
+    {
       // WHEN: Props interface name does not follow ${ConstructName}Props format
       code: `
         class Construct {}

--- a/packages/eslint/src/core/ast-node/finder/constructor.ts
+++ b/packages/eslint/src/core/ast-node/finder/constructor.ts
@@ -1,14 +1,8 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 
 /**
- * Finds the constructor implementation in a class declaration
- *
- * When a class has overload signatures on its constructor, the class body contains
- * multiple constructor members. Only the implementation signature has a body
- * (its `value` is a `FunctionExpression`, not `TSEmptyBodyFunctionExpression`).
- * Callers of this finder always want to inspect the implementation, so overload
- * signatures are skipped.
- *
+ * Finds the constructor implementation in a class declaration.
+ * Overload signatures (body-less `TSEmptyBodyFunctionExpression` values) are skipped.
  * @param node The class declaration
  * @returns The constructor implementation or undefined if not found
  */

--- a/packages/eslint/src/core/ast-node/finder/constructor.ts
+++ b/packages/eslint/src/core/ast-node/finder/constructor.ts
@@ -1,15 +1,24 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 
 /**
- * Finds the constructor method in a class declaration
+ * Finds the constructor implementation in a class declaration
+ *
+ * When a class has overload signatures on its constructor, the class body contains
+ * multiple constructor members. Only the implementation signature has a body
+ * (its `value` is a `FunctionExpression`, not `TSEmptyBodyFunctionExpression`).
+ * Callers of this finder always want to inspect the implementation, so overload
+ * signatures are skipped.
+ *
  * @param node The class declaration
- * @returns The constructor method definition or undefined if not found
+ * @returns The constructor implementation or undefined if not found
  */
 export const findConstructor = (
   node: TSESTree.ClassDeclaration,
 ): TSESTree.MethodDefinition | undefined => {
   return node.body.body.find(
     (member): member is TSESTree.MethodDefinition =>
-      member.type === AST_NODE_TYPES.MethodDefinition && member.kind === "constructor",
+      member.type === AST_NODE_TYPES.MethodDefinition &&
+      member.kind === "constructor" &&
+      member.value.type !== AST_NODE_TYPES.TSEmptyBodyFunctionExpression,
   );
 };

--- a/packages/oxlint/src/__tests__/construct-constructor-property.test.ts
+++ b/packages/oxlint/src/__tests__/construct-constructor-property.test.ts
@@ -213,5 +213,24 @@ ruleTester.run("construct-constructor-property", constructConstructorProperty, {
       `,
       errors: [{ messageId: "invalidConstructorProperty" }],
     },
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string);
+        constructor(scope: Construct, id: string, props: MyConstructProps);
+        constructor(parent: Construct, name: string, opts?: MyConstructProps) {
+          super(parent, name);
+        }
+      }
+      `,
+      errors: [
+        { messageId: "invalidConstructorProperty" },
+        { messageId: "invalidConstructorProperty" },
+        { messageId: "invalidConstructorProperty" },
+      ],
+    },
   ],
 });

--- a/packages/oxlint/src/__tests__/no-unused-props.test.ts
+++ b/packages/oxlint/src/__tests__/no-unused-props.test.ts
@@ -501,6 +501,26 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       }
       `,
     },
+    {
+      name: "Constructor with overload signatures: all props are used in the implementation body",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string);
+        constructor(scope: Construct, id: string, props: MyConstructProps);
+        constructor(scope: Construct, id: string, props?: MyConstructProps) {
+          super(scope, id);
+          console.log(props?.bucketName, props?.enableVersioning);
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/oxlint/src/__tests__/props-name-convention.test.ts
+++ b/packages/oxlint/src/__tests__/props-name-convention.test.ts
@@ -47,6 +47,30 @@ ruleTester.run("props-name-convention", propsNameConvention, {
   ],
   invalid: [
     {
+      // WHEN: constructor has an overload signature and the implementation takes wrongly named props
+      code: `
+        class Construct {}
+        interface Props {
+          readonly bucket?: string;
+        }
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string);
+          constructor(scope: Construct, id: string, props?: Props) {
+            super(scope, id);
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidPropsName",
+          data: {
+            interfaceName: "Props",
+            expectedName: "MyConstructProps",
+          },
+        },
+      ],
+    },
+    {
       // WHEN: Props interface name does not follow ${ConstructName}Props format
       code: `
         class Construct {}

--- a/packages/oxlint/src/core/ast-node/finder/constructor.ts
+++ b/packages/oxlint/src/core/ast-node/finder/constructor.ts
@@ -3,15 +3,24 @@ import type { ESTree } from "corsa-oxlint";
 import { AST_NODE_TYPES } from "corsa-oxlint";
 
 /**
- * Finds the constructor method in a class declaration / expression
+ * Finds the constructor implementation in a class declaration / expression
+ *
+ * When a class has overload signatures on its constructor, the class body contains
+ * multiple constructor members. Only the implementation signature has a body
+ * (its `value` is a `FunctionExpression`, not `TSEmptyBodyFunctionExpression`).
+ * Callers of this finder always want to inspect the implementation, so overload
+ * signatures are skipped.
+ *
  * @param node The class declaration or expression
- * @returns The constructor method definition or undefined if not found
+ * @returns The constructor implementation or undefined if not found
  */
 export const findConstructor = (
   node: ESTree.ClassDeclaration | ESTree.ClassExpression,
 ): ESTree.MethodDefinition | undefined => {
   return node.body.body.find(
     (member): member is ESTree.MethodDefinition =>
-      member.type === AST_NODE_TYPES.MethodDefinition && member.kind === "constructor",
+      member.type === AST_NODE_TYPES.MethodDefinition &&
+      member.kind === "constructor" &&
+      member.value.type !== AST_NODE_TYPES.TSEmptyBodyFunctionExpression,
   );
 };

--- a/packages/oxlint/src/core/ast-node/finder/constructor.ts
+++ b/packages/oxlint/src/core/ast-node/finder/constructor.ts
@@ -3,14 +3,8 @@ import type { ESTree } from "corsa-oxlint";
 import { AST_NODE_TYPES } from "corsa-oxlint";
 
 /**
- * Finds the constructor implementation in a class declaration / expression
- *
- * When a class has overload signatures on its constructor, the class body contains
- * multiple constructor members. Only the implementation signature has a body
- * (its `value` is a `FunctionExpression`, not `TSEmptyBodyFunctionExpression`).
- * Callers of this finder always want to inspect the implementation, so overload
- * signatures are skipped.
- *
+ * Finds the constructor implementation in a class declaration / expression.
+ * Overload signatures (body-less `TSEmptyBodyFunctionExpression` values) are skipped.
  * @param node The class declaration or expression
  * @returns The constructor implementation or undefined if not found
  */


### PR DESCRIPTION
### Issue # (if applicable)

Closes #533.

### Reason for this change

`findConstructor` returned the first class member whose kind is `constructor`, which is the body-less overload signature when the constructor is overloaded. `construct-constructor-property` then validated only the overload signature (missing wrong parameter names in the implementation), and `no-unused-props` analyzed a constructor without a body and reported every property as unused.

### Description of changes

Skip overload signatures (`TSEmptyBodyFunctionExpression` values) in the shared `findConstructor` finder so callers always receive the implementation signature, in both plugins.

### Description of how you validated changes

- Added an overloaded-constructor invalid case to construct-constructor-property and a valid case to no-unused-props in both plugins; `vp check` and `vp test --run` (504/504) pass.
- Confirmed with the issue repro that the implementation's wrong parameter names are now reported and the props false positive is gone, identically on both plugins.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_