### PR TITLE
fix: report unannotated public properties in no-mutable-public-property-of-construct

### DIFF
--- a/packages/eslint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -112,6 +112,32 @@ ruleTester.run(
         `,
       },
       {
+        name: "field has no type annotation but initializer is Construct instance (not inferred)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            public readonly bucket = new Bucket();
+          }
+        `,
+      },
+      {
         name: "class does not extend Construct",
         code: `
           class Resource {}

--- a/packages/eslint/src/__tests__/no-mutable-public-property-of-construct.test.ts
+++ b/packages/eslint/src/__tests__/no-mutable-public-property-of-construct.test.ts
@@ -71,6 +71,15 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           }
         `,
     },
+    // WHEN: public field is readonly and has no type annotation (initializer-inferred)
+    {
+      code: `
+          class Construct {}
+          class TestClass extends Construct {
+            public readonly inferred = 0;
+          }
+        `,
+    },
   ],
   invalid: [
     // WHEN: public field is mutable, nested superClass is Construct
@@ -176,6 +185,22 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           class Construct {}
           class TestClass extends Construct {
             public static readonly defaultName: string = "sample";
+          }
+        `,
+    },
+    // WHEN: public field is mutable and has no type annotation (initializer-inferred)
+    {
+      code: `
+          class Construct {}
+          class TestClass extends Construct {
+            public inferred = 0;
+          }
+        `,
+      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      output: `
+          class Construct {}
+          class TestClass extends Construct {
+            public readonly inferred = 0;
           }
         `,
     },

--- a/packages/eslint/src/__tests__/no-mutable-public-property-of-construct.test.ts
+++ b/packages/eslint/src/__tests__/no-mutable-public-property-of-construct.test.ts
@@ -204,5 +204,25 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           }
         `,
     },
+    // WHEN: constructor parameter property is mutable and has no type annotation
+    {
+      code: `
+          class Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public count) {
+              super(scope, id);
+            }
+          }
+        `,
+      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      output: `
+          class Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public readonly count) {
+              super(scope, id);
+            }
+          }
+        `,
+    },
   ],
 });

--- a/packages/eslint/src/core/ast-node/finder/public-property.ts
+++ b/packages/eslint/src/core/ast-node/finder/public-property.ts
@@ -14,6 +14,11 @@ export type PublicProperty = {
     | TSESTree.PropertyDefinitionComputedName
     | TSESTree.PropertyDefinitionNonComputedName
     | TSESTree.TSParameterProperty;
+  /**
+   * Type annotation attached to the property, if any.
+   * Absent when the property has no explicit annotation (e.g. `public foo = 0;`).
+   */
+  typeAnnotation?: TSESTree.TSTypeAnnotation;
 };
 
 export const findPublicPropertiesInClass = (node: TSESTree.ClassDeclaration): PublicProperty[] => {
@@ -44,10 +49,10 @@ const findPublicProperty = (
       if (["private", "protected"].includes(property.accessibility ?? "")) {
         return;
       }
-      if (!property.parameter.typeAnnotation) return;
       return {
         name: property.parameter.name,
         node: property,
+        typeAnnotation: property.parameter.typeAnnotation,
       };
     }
     // NOTE: get from class element
@@ -58,10 +63,10 @@ const findPublicProperty = (
       if (["private", "protected"].includes(property.accessibility ?? "")) {
         return;
       }
-      if (!property.typeAnnotation) return;
       return {
         name: property.key.name,
         node: property,
+        typeAnnotation: property.typeAnnotation,
       };
     }
   }

--- a/packages/eslint/src/rules/no-construct-in-public-property-of-construct.ts
+++ b/packages/eslint/src/rules/no-construct-in-public-property-of-construct.ts
@@ -15,6 +15,7 @@ type Context = TSESLint.RuleContext<"invalidPublicPropertyOfConstruct", []>;
 type PublicProperty = {
   name: string;
   node: TSESTree.Parameter | TSESTree.ClassElement;
+  typeAnnotation?: TSESTree.TSTypeAnnotation;
 };
 
 /**
@@ -56,6 +57,10 @@ const validatePublicProperty = (
   context: Context,
   parserServices: ParserServicesWithTypeInformation,
 ) => {
+  // Only inspect properties that have an explicit type annotation.
+  // Inferring the type from an initializer is out of scope for this rule.
+  if (!publicProperty.typeAnnotation) return;
+
   const type = parserServices.getTypeAtLocation(publicProperty.node);
   const constructType = findTypeOfCdkConstruct(type);
   if (constructType) {

--- a/packages/oxlint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/packages/oxlint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -106,6 +106,32 @@ ruleTester.run(
         `,
       },
       {
+        name: "field has no type annotation but initializer is Construct instance (not inferred)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            public readonly bucket = new Bucket();
+          }
+        `,
+      },
+      {
         name: "class does not extend Construct",
         code: `
           class Resource {}

--- a/packages/oxlint/src/__tests__/no-mutable-public-property-of-construct.test.ts
+++ b/packages/oxlint/src/__tests__/no-mutable-public-property-of-construct.test.ts
@@ -60,6 +60,14 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           }
         `,
     },
+    {
+      code: `
+          class Construct {}
+          class TestClass extends Construct {
+            public readonly inferred = 0;
+          }
+        `,
+    },
   ],
   invalid: [
     {
@@ -159,6 +167,21 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           class Construct {}
           class TestClass extends Construct {
             public static readonly defaultName: string = "sample";
+          }
+        `,
+    },
+    {
+      code: `
+          class Construct {}
+          class TestClass extends Construct {
+            public inferred = 0;
+          }
+        `,
+      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      output: `
+          class Construct {}
+          class TestClass extends Construct {
+            public readonly inferred = 0;
           }
         `,
     },

--- a/packages/oxlint/src/__tests__/no-mutable-public-property-of-construct.test.ts
+++ b/packages/oxlint/src/__tests__/no-mutable-public-property-of-construct.test.ts
@@ -185,5 +185,24 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           }
         `,
     },
+    {
+      code: `
+          class Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public count) {
+              super(scope, id);
+            }
+          }
+        `,
+      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      output: `
+          class Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public readonly count) {
+              super(scope, id);
+            }
+          }
+        `,
+    },
   ],
 });

--- a/packages/oxlint/src/core/ast-node/finder/public-property.ts
+++ b/packages/oxlint/src/core/ast-node/finder/public-property.ts
@@ -15,6 +15,11 @@ export type PublicProperty = {
    * AST node representing the public property
    */
   node: ESTree.TSParameterProperty | ESTree.PropertyDefinition;
+  /**
+   * Type annotation attached to the property, if any.
+   * Absent when the property has no explicit annotation (e.g. `public foo = 0;`).
+   */
+  typeAnnotation?: ESTree.TSTypeAnnotation | null;
 };
 
 export const findPublicPropertiesInClass = (node: Class): PublicProperty[] => {
@@ -39,19 +44,19 @@ const findPublicProperty = (property: ESTree.Node): PublicProperty | undefined =
     case AST_NODE_TYPES.TSParameterProperty: {
       if (property.parameter.type !== AST_NODE_TYPES.Identifier) return;
       if (["private", "protected"].includes(property.accessibility ?? "")) return;
-      if (!property.parameter.typeAnnotation) return;
       return {
         name: property.parameter.name,
         node: property,
+        typeAnnotation: property.parameter.typeAnnotation,
       };
     }
     case AST_NODE_TYPES.PropertyDefinition: {
       if (property.key.type !== AST_NODE_TYPES.Identifier) return;
       if (["private", "protected"].includes(property.accessibility ?? "")) return;
-      if (!property.typeAnnotation) return;
       return {
         name: property.key.name,
         node: property,
+        typeAnnotation: property.typeAnnotation,
       };
     }
   }

--- a/packages/oxlint/src/rules/no-construct-in-public-property-of-construct.ts
+++ b/packages/oxlint/src/rules/no-construct-in-public-property-of-construct.ts
@@ -49,6 +49,10 @@ const validatePublicProperty = (
   context: RuleContext,
   parserServices: ParserServices,
 ) => {
+  // Only inspect properties that have an explicit type annotation.
+  // Inferring the type from an initializer is out of scope for this rule.
+  if (!publicProperty.typeAnnotation) return;
+
   const type = parserServices.getTypeAtLocation(publicProperty.node);
   const checker = parserServices.program.getTypeChecker();
   const constructType = findTypeOfCdkConstruct(type, checker);


### PR DESCRIPTION
### Issue # (if applicable)

Closes #541.

### Reason for this change

The shared `findPublicPropertiesInClass` finder skipped any property without an explicit type annotation, so `no-mutable-public-property-of-construct` never reported `public inferred = 0;` — although mutability does not depend on whether the type is written out. The annotation requirement only makes sense for `no-construct-in-public-property-of-construct`, which inspects the annotated type.

### Description of changes

Remove the annotation filter from the shared finder (exposing the annotation on `PublicProperty` instead) and move the annotation requirement into `no-construct-in-public-property-of-construct`, in both plugins. The readonly rule now reports unannotated public properties; the construct-type rule keeps its behavior unchanged.

### Description of how you validated changes

- Added valid / invalid (with autofix `output`) unannotated cases to the readonly rule and a regression valid case to the construct-type rule in both plugins; `vp check` and `vp test --run` (510/510) pass.
- Confirmed with the issue repro that `public inferred = 0;` is now reported identically by both plugins.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_