### PR TITLE
fix: check all generic type arguments in eslint plugin

### DIFF
--- a/packages/eslint/src/__tests__/no-construct-in-interface.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-in-interface.test.ts
@@ -578,6 +578,32 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       errors: [{ messageId: "invalidInterfaceProperty" }],
     },
     {
+      name: "property type is a nested generic with Construct (Record<string, Bucket[]>)",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        nestedBuckets: Record<string, Bucket[]>;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
+    {
       name: "property type is Map with Construct as value type (Map<string, Bucket>)",
       code: `
       class Resource {}

--- a/packages/eslint/src/__tests__/no-construct-in-interface.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-in-interface.test.ts
@@ -96,6 +96,17 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       `,
     },
     {
+      name: "property type is Record with interface value (Record<string, IBucket>)",
+      code: `
+      interface IBucket {
+        bucketName: string;
+      }
+      interface MyConstructProps {
+        bucketsByName: Record<string, IBucket>;
+      }
+      `,
+    },
+    {
       name: `property type is interface (not construct class) even if there is a class implementing it in module`,
       code: `
       class Resource {}
@@ -536,6 +547,84 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       }
       interface MyConstructProps {
         bucket: [Bucket, Bucket];
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
+    {
+      name: "property type is Record with Construct as value type (Record<string, Bucket>)",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        bucketsByName: Record<string, Bucket>;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
+    {
+      name: "property type is Map with Construct as value type (Map<string, Bucket>)",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        bucketMap: Map<string, Bucket>;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
+    {
+      name: "property type is tuple with Construct at non-zero position ([string, Bucket])",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        pair: [string, Bucket];
       }
       `,
       errors: [{ messageId: "invalidInterfaceProperty" }],

--- a/packages/eslint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -163,6 +163,33 @@ ruleTester.run(
     ],
     invalid: [
       {
+        name: "public field type is Record with Construct as value type (Record<string, Bucket>)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            public bucketMap: Record<string, Bucket>;
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
+      {
         name: "public field type is class that extends Resource (Bucket extends BucketBase)",
         code: `
           class Construct {}

--- a/packages/eslint/src/core/cdk-construct/type-finder/index.ts
+++ b/packages/eslint/src/core/cdk-construct/type-finder/index.ts
@@ -31,13 +31,16 @@ const findFromArray = (type: Type): Type | undefined => {
 };
 
 /**
- * Find Construct type from a generics type (e.g. Array<s3.Bucket>, Promise<s3.Bucket[]>)
+ * Find Construct type from a generics type
+ * (e.g. Array<s3.Bucket>, Record<string, s3.Bucket>, [string, s3.Bucket], Promise<s3.Bucket[]>).
+ * Walks every type argument so that Constructs at non-zero positions are also detected.
  */
 const findFromGenerics = (type: Type): Type | undefined => {
-  const genericsArgument = findGenericsTypeArgument(type);
-  if (!genericsArgument) return undefined;
-
-  return findTypeOfCdkConstruct(genericsArgument);
+  for (const argument of findGenericsTypeArgument(type)) {
+    const foundType = findTypeOfCdkConstruct(argument);
+    if (foundType) return foundType;
+  }
+  return undefined;
 };
 
 /**

--- a/packages/eslint/src/core/ts-type/finder/generics-type-argument.ts
+++ b/packages/eslint/src/core/ts-type/finder/generics-type-argument.ts
@@ -1,43 +1,42 @@
 import { Type } from "typescript";
 
 /**
- * Extracts the type argument from a generics type reference (e.g. Array<s3.Bucket>, returns s3.Bucket)
- * @param type - The type to check
- * @returns The first type argument if it's a generics type reference, undefined otherwise
+ * Extracts all type arguments from a generics type reference
+ * (e.g. Array<s3.Bucket> -> [s3.Bucket], Record<string, s3.Bucket> -> [string, s3.Bucket]).
+ * Mirrors the oxlint plugin's checker.getTypeArguments walk so both linters detect
+ * Construct types in any position (fixes #537).
  */
-export const findGenericsTypeArgument = (type: Type): Type | undefined => {
-  // NOTE: Check for type alias (e.g. Readonly<T>, Partial<T>)
+export const findGenericsTypeArgument = (type: Type): readonly Type[] => {
+  // Check for type alias (e.g. Readonly<T>, Partial<T>)
   if (
     "aliasSymbol" in type &&
     type.aliasSymbol &&
     "aliasTypeArguments" in type &&
     type.aliasTypeArguments?.length
   ) {
-    return type.aliasTypeArguments[0];
+    return [...type.aliasTypeArguments];
   }
 
-  // NOTE: Check if type has typeArguments (generics types like Array<T>, etc.)
-  //       This works for TypeReference types
-  if ("typeArguments" in type && Array.isArray(type.typeArguments) && type.typeArguments?.length) {
-    return type.typeArguments[0] as Type;
+  // Check for typeArguments (generics/TypeReference like Array<T>, Record<K, V>, tuples)
+  if ("typeArguments" in type && Array.isArray(type.typeArguments) && type.typeArguments.length) {
+    return [...(type.typeArguments as readonly Type[])];
   }
 
-  // NOTE: Alternative approach: check for target property (some generics types have this)
   if (
     "target" in type &&
     type.target &&
     "typeArguments" in type &&
     Array.isArray(type.typeArguments) &&
-    type.typeArguments?.length
+    type.typeArguments.length
   ) {
-    return type.typeArguments[0] as Type;
+    return [...(type.typeArguments as readonly Type[])];
   }
 
-  // NOTE: For mapped types like Readonly<T> and Partial<T>
-  //       These are represented differently in TypeScript's type system
+  // Mapped types like Readonly<T> / Partial<T> lose typeArguments after
+  // resolution; modifiersType exposes the wrapped type.
   if ("modifiersType" in type && type.modifiersType) {
-    return type.modifiersType as Type;
+    return [type.modifiersType as Type];
   }
 
-  return undefined;
+  return [];
 };

--- a/packages/oxlint/src/__tests__/no-construct-in-interface.test.ts
+++ b/packages/oxlint/src/__tests__/no-construct-in-interface.test.ts
@@ -110,6 +110,17 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       `,
     },
     {
+      name: "property type is Record with interface value (Record<string, IBucket>)",
+      code: `
+      interface IBucket {
+        bucketName: string;
+      }
+      interface MyConstructProps {
+        bucketsByName: Record<string, IBucket>;
+      }
+      `,
+    },
+    {
       name: "property type is Pick utility type wrapping a plain interface (regression for #492)",
       code: `
       interface AlarmProps {
@@ -188,6 +199,110 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       }
       interface MyConstructProps {
         bucket: Bucket;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
+    {
+      name: "property type is Record with Construct as value type (Record<string, Bucket>)",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        bucketsByName: Record<string, Bucket>;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
+    {
+      name: "property type is a nested generic with Construct (Record<string, Bucket[]>)",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        nestedBuckets: Record<string, Bucket[]>;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
+    {
+      name: "property type is Map with Construct as value type (Map<string, Bucket>)",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        bucketMap: Map<string, Bucket>;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
+    {
+      name: "property type is tuple with Construct at non-zero position ([string, Bucket])",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        pair: [string, Bucket];
       }
       `,
       errors: [{ messageId: "invalidInterfaceProperty" }],

--- a/packages/oxlint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/packages/oxlint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -179,6 +179,33 @@ ruleTester.run(
     ],
     invalid: [
       {
+        name: "public field type is Record with Construct as value type (Record<string, Bucket>)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            public bucketMap: Record<string, Bucket>;
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
+      {
         name: "public field type is class that extends Resource (Bucket extends BucketBase)",
         code: `
           class Construct {}


### PR DESCRIPTION
### Issue # (if applicable)

Closes #537.

### Reason for this change

eslint-plugin-awscdk's `findGenericsTypeArgument` returned only the first type argument, so `no-construct-in-interface` missed Construct types in the second or later position (`Record<string, Bucket>`, `Map<string, Bucket>`, tuples) — diverging from oxlint-plugin-awscdk, which walks all type arguments.

### Description of changes

Change the finder to return all type arguments and walk them in the shared CDK type finder, mirroring the oxlint implementation. `no-construct-in-public-property-of-construct` uses the same path and is fixed by the same change.

### Description of how you validated changes

- Added `Record` / `Map` / tuple invalid cases and a `Record<string, IBucket>` valid case to the no-construct-in-interface suite; `vp check` and `vp test --run` (508/508) pass.
- Confirmed with the issue repro that the eslint plugin now reports all five properties, byte-identical to the oxlint plugin's output.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_