### PR TITLE
fix: apply rule option defaults when an empty options object is passed

### DIFF
--- a/packages/eslint/src/__tests__/no-construct-stack-suffix.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-stack-suffix.test.ts
@@ -179,5 +179,31 @@ ruleTester.run("no-construct-stack-suffix", noConstructStackSuffix, {
       new SampleConstruct({ name: "sample" }, \`TemplateBucketConstruct\`);`,
       errors: [{ messageId: "invalidConstructId" }],
     },
+    // WHEN: an empty options object is passed, defaults must still apply ("Construct" is disallowed)
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      new SampleConstruct({ name: "sample" }, "SampleConstruct");`,
+      options: [{}],
+      errors: [{ messageId: "invalidConstructId" }],
+    },
+    // WHEN: an empty options object is passed, defaults must still apply ("Stack" is disallowed)
+    {
+      code: `
+      class Stack {}
+      class SampleStack extends Stack {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      new SampleStack({ name: "sample" }, "SampleStack");`,
+      options: [{}],
+      errors: [{ messageId: "invalidConstructId" }],
+    },
   ],
 });

--- a/packages/eslint/src/__tests__/require-passing-this.test.ts
+++ b/packages/eslint/src/__tests__/require-passing-this.test.ts
@@ -150,6 +150,24 @@ ruleTester.run("require-passing-this", requirePassingThis, {
       }
       `,
     },
+    // WHEN: no options are passed, the default (`allowNonThisAndDisallowScope: true`) applies
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const sample = new SampleConstruct(this, "Sample");
+          new SampleConstruct(sample, "ValidId");
+        }
+      }
+      `,
+    },
     // WHEN: an empty options object is passed, the default (`allowNonThisAndDisallowScope: true`) still applies
     {
       code: `

--- a/packages/eslint/src/__tests__/require-passing-this.test.ts
+++ b/packages/eslint/src/__tests__/require-passing-this.test.ts
@@ -150,6 +150,25 @@ ruleTester.run("require-passing-this", requirePassingThis, {
       }
       `,
     },
+    // WHEN: an empty options object is passed, the default (`allowNonThisAndDisallowScope: true`) still applies
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const sample = new SampleConstruct(this, "Sample");
+          new SampleConstruct(sample, "ValidId");
+        }
+      }
+      `,
+      options: [{}],
+    },
   ],
   invalid: [
     // WHEN: passing 'scope' variable

--- a/packages/eslint/src/rules/no-construct-stack-suffix.ts
+++ b/packages/eslint/src/rules/no-construct-stack-suffix.ts
@@ -59,6 +59,8 @@ export const noConstructStackSuffix = createRule({
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
     const checker = parserServices.program.getTypeChecker();
+    // Merge user-supplied options over defaults so `[{}]` behaves like `[]`.
+    const options: Option = { ...defaultOption, ...context.options[0] };
 
     return {
       NewExpression(node) {
@@ -71,7 +73,7 @@ export const noConstructStackSuffix = createRule({
         const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[1] !== "id") return;
 
-        validateConstructId(node, context);
+        validateConstructId(node, context, options);
       },
     };
   },
@@ -80,9 +82,11 @@ export const noConstructStackSuffix = createRule({
 /**
  * Validate that construct ID does not end with "Construct" or "Stack"
  */
-const validateConstructId = (node: TSESTree.NewExpression, context: Context): void => {
-  const options = context.options[0] ?? defaultOption;
-
+const validateConstructId = (
+  node: TSESTree.NewExpression,
+  context: Context,
+  options: Option,
+): void => {
   // NOTE: Treat the second argument as ID
   const secondArg = node.arguments[1];
   const constructId = findConstructIdString(secondArg);

--- a/packages/eslint/src/rules/require-passing-this.ts
+++ b/packages/eslint/src/rules/require-passing-this.ts
@@ -37,7 +37,7 @@ export const requirePassingThis = createRule({
         properties: {
           allowNonThisAndDisallowScope: {
             type: "boolean",
-            default: false,
+            default: true,
           },
         },
         additionalProperties: false,
@@ -47,7 +47,8 @@ export const requirePassingThis = createRule({
   },
   defaultOptions: [defaultOption],
   create(context: Context) {
-    const options = context.options[0] || defaultOption;
+    // Merge user-supplied options over defaults so `[{}]` behaves like `[]`.
+    const options: Option = { ...defaultOption, ...context.options[0] };
     const parserServices = ESLintUtils.getParserServices(context);
     const checker = parserServices.program.getTypeChecker();
     return {

--- a/packages/oxlint/src/__tests__/no-construct-stack-suffix.test.ts
+++ b/packages/oxlint/src/__tests__/no-construct-stack-suffix.test.ts
@@ -148,5 +148,29 @@ ruleTester.run("no-construct-stack-suffix", noConstructStackSuffix, {
       new SampleConstruct({ name: "sample" }, \`TemplateBucketConstruct\`);`,
       errors: [{ messageId: "invalidConstructId" }],
     },
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      new SampleConstruct({ name: "sample" }, "SampleConstruct");`,
+      options: [{}],
+      errors: [{ messageId: "invalidConstructId" }],
+    },
+    {
+      code: `
+      class Stack {}
+      class SampleStack extends Stack {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      new SampleStack({ name: "sample" }, "SampleStack");`,
+      options: [{}],
+      errors: [{ messageId: "invalidConstructId" }],
+    },
   ],
 });

--- a/packages/oxlint/src/__tests__/require-passing-this.test.ts
+++ b/packages/oxlint/src/__tests__/require-passing-this.test.ts
@@ -129,6 +129,23 @@ ruleTester.run("require-passing-this", requirePassingThis, {
         }
       }
       `,
+    },
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const sample = new SampleConstruct(this, "Sample");
+          new SampleConstruct(sample, "ValidId");
+        }
+      }
+      `,
       options: [{}],
     },
   ],

--- a/packages/oxlint/src/__tests__/require-passing-this.test.ts
+++ b/packages/oxlint/src/__tests__/require-passing-this.test.ts
@@ -113,6 +113,24 @@ ruleTester.run("require-passing-this", requirePassingThis, {
       `,
       options: [{ allowNonThisAndDisallowScope: true }],
     },
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const sample = new SampleConstruct(this, "Sample");
+          new SampleConstruct(sample, "ValidId");
+        }
+      }
+      `,
+      options: [{}],
+    },
   ],
   invalid: [
     {

--- a/packages/oxlint/src/rules/no-construct-stack-suffix.ts
+++ b/packages/oxlint/src/rules/no-construct-stack-suffix.ts
@@ -58,7 +58,8 @@ export const noConstructStackSuffix = createRule({
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
     const checker = parserServices.program.getTypeChecker();
-    const options: Option = context.options[0] ?? defaultOption;
+    // Merge user-supplied options over defaults so `[{}]` behaves like `[]`.
+    const options: Option = { ...defaultOption, ...context.options[0] };
 
     return {
       NewExpression(node) {

--- a/packages/oxlint/src/rules/require-passing-this.ts
+++ b/packages/oxlint/src/rules/require-passing-this.ts
@@ -34,7 +34,7 @@ export const requirePassingThis = createRule({
         properties: {
           allowNonThisAndDisallowScope: {
             type: "boolean",
-            default: false,
+            default: true,
           },
         },
         additionalProperties: false,
@@ -44,7 +44,8 @@ export const requirePassingThis = createRule({
   },
   defaultOptions: [defaultOption],
   create(context) {
-    const options: Option = context.options[0] ?? defaultOption;
+    // Merge user-supplied options over defaults so `[{}]` behaves like `[]`.
+    const options: Option = { ...defaultOption, ...context.options[0] };
     const parserServices = ESLintUtils.getParserServices(context);
     const checker = parserServices.program.getTypeChecker();
     return {


### PR DESCRIPTION
### Issue # (if applicable)

Closes #538.

### Reason for this change

Configuring a rule as `["error", {}]` behaved differently from `["error"]`: the rules read `context.options[0] ?? defaultOption`, and an empty object is truthy, so the coded defaults were skipped. This silently disabled `no-construct-stack-suffix` (no `disallowedSuffixes`), and flipped `require-passing-this` to strict mode because its schema declared `default: false` while the documented and coded default is `true` (AJV `useDefaults` rewrote `{}` accordingly).

### Description of changes

Merge the user-supplied options object over the rule defaults (`{ ...defaultOption, ...context.options[0] }`) in both rules, mirrored in both plugins, and align the `require-passing-this` schema `default` with the documented default (`true`).

### Description of how you validated changes

- Added `options: [{}]` cases to both rules' suites in both plugins: `no-construct-stack-suffix` still reports `Construct` / `Stack` suffixes, and `require-passing-this` still allows non-`this` variables (default `allowNonThisAndDisallowScope: true`).
- `vp check` and `vp test --run` (552/552) pass.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_