### PR TITLE
fix: make pascal-case-construct-id autofix converge to a valid id or offer no fix

### DIFF
--- a/packages/eslint/src/__tests__/pascal-case-construct-id.test.ts
+++ b/packages/eslint/src/__tests__/pascal-case-construct-id.test.ts
@@ -197,5 +197,38 @@ ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
       }
       const test = new TestClass('test', \`TemplateBucket\`);`,
     },
+    // WHEN: id is separated by a non-alphanumeric symbol (e.g. dot)
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', "my.bucket");`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', "MyBucket");`,
+    },
+    // WHEN: id starts with digits — reported but not fixable (fix must not diverge)
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', "123bucket");`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
   ],
 });

--- a/packages/eslint/src/rules/pascal-case-construct-id.ts
+++ b/packages/eslint/src/rules/pascal-case-construct-id.ts
@@ -89,7 +89,6 @@ const validateConstructId = (node: TSESTree.NewExpression, context: Context) => 
   if (isPascalCase(constructId)) return;
 
   const pascalCaseValue = toPascalCase(constructId);
-  const quote = findQuoteType(secondArg);
   // Skip the fix when the converted value would still fail validation
   // (e.g. leading digits, symbol-only input) so the fix always converges.
   if (!isPascalCase(pascalCaseValue)) {
@@ -97,6 +96,7 @@ const validateConstructId = (node: TSESTree.NewExpression, context: Context) => 
     return;
   }
 
+  const quote = findQuoteType(secondArg);
   context.report({
     node: secondArg,
     messageId: "invalidConstructId",

--- a/packages/eslint/src/rules/pascal-case-construct-id.ts
+++ b/packages/eslint/src/rules/pascal-case-construct-id.ts
@@ -88,14 +88,18 @@ const validateConstructId = (node: TSESTree.NewExpression, context: Context) => 
 
   if (isPascalCase(constructId)) return;
 
+  const pascalCaseValue = toPascalCase(constructId);
   const quote = findQuoteType(secondArg);
+  // Skip the fix when the converted value would still fail validation
+  // (e.g. leading digits, symbol-only input) so the fix always converges.
+  if (!isPascalCase(pascalCaseValue)) {
+    context.report({ node: secondArg, messageId: "invalidConstructId" });
+    return;
+  }
 
   context.report({
     node: secondArg,
     messageId: "invalidConstructId",
-    fix: (fixer) => {
-      const pascalCaseValue = toPascalCase(constructId);
-      return fixer.replaceText(secondArg, `${quote}${pascalCaseValue}${quote}`);
-    },
+    fix: (fixer) => fixer.replaceText(secondArg, `${quote}${pascalCaseValue}${quote}`),
   });
 };

--- a/packages/eslint/src/shared/converter/to-pascal-case.ts
+++ b/packages/eslint/src/shared/converter/to-pascal-case.ts
@@ -5,7 +5,7 @@
  */
 export const toPascalCase = (str: string): string => {
   return str
-    .split(/[-_\s]/)
+    .split(/[^A-Za-z0-9]+/)
     .map((word) => {
       // Consider camelCase, split by uppercase letters
       return word

--- a/packages/oxlint/src/__tests__/pascal-case-construct-id.test.ts
+++ b/packages/oxlint/src/__tests__/pascal-case-construct-id.test.ts
@@ -157,5 +157,36 @@ ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
       }
       const test = new TestClass('test', \`TemplateBucket\`);`,
     },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', "my.bucket");`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', "MyBucket");`,
+    },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      const test = new TestClass('test', "123bucket");`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
   ],
 });

--- a/packages/oxlint/src/rules/pascal-case-construct-id.ts
+++ b/packages/oxlint/src/rules/pascal-case-construct-id.ts
@@ -84,14 +84,18 @@ const validateConstructId = (node: ESTree.NewExpression, context: RuleContext) =
 
   if (isPascalCase(constructId)) return;
 
+  const pascalCaseValue = toPascalCase(constructId);
   const quote = findQuoteType(secondArg);
+  // Skip the fix when the converted value would still fail validation
+  // (e.g. leading digits, symbol-only input) so the fix always converges.
+  if (!isPascalCase(pascalCaseValue)) {
+    context.report({ node: secondArg, messageId: "invalidConstructId" });
+    return;
+  }
 
   context.report({
     node: secondArg,
     messageId: "invalidConstructId",
-    fix: (fixer) => {
-      const pascalCaseValue = toPascalCase(constructId);
-      return fixer.replaceText(secondArg, `${quote}${pascalCaseValue}${quote}`);
-    },
+    fix: (fixer) => fixer.replaceText(secondArg, `${quote}${pascalCaseValue}${quote}`),
   });
 };

--- a/packages/oxlint/src/rules/pascal-case-construct-id.ts
+++ b/packages/oxlint/src/rules/pascal-case-construct-id.ts
@@ -85,7 +85,6 @@ const validateConstructId = (node: ESTree.NewExpression, context: RuleContext) =
   if (isPascalCase(constructId)) return;
 
   const pascalCaseValue = toPascalCase(constructId);
-  const quote = findQuoteType(secondArg);
   // Skip the fix when the converted value would still fail validation
   // (e.g. leading digits, symbol-only input) so the fix always converges.
   if (!isPascalCase(pascalCaseValue)) {
@@ -93,6 +92,7 @@ const validateConstructId = (node: ESTree.NewExpression, context: RuleContext) =
     return;
   }
 
+  const quote = findQuoteType(secondArg);
   context.report({
     node: secondArg,
     messageId: "invalidConstructId",

--- a/packages/oxlint/src/shared/converter/to-pascal-case.ts
+++ b/packages/oxlint/src/shared/converter/to-pascal-case.ts
@@ -5,7 +5,7 @@
  */
 export const toPascalCase = (str: string): string => {
   return str
-    .split(/[-_\s]/)
+    .split(/[^A-Za-z0-9]+/)
     .map((word) => {
       // Consider camelCase, split by uppercase letters
       return word


### PR DESCRIPTION
### Issue # (if applicable)

Closes #539.

### Reason for this change

The `pascal-case-construct-id` autofix replaced the ID with `toPascalCase(id)`, but the converter only handled `[-_\s]` separators and camelCase boundaries. For IDs with other symbols (`"my.bucket"`) the fix output still violated PascalCase, and for IDs starting with digits (`"123bucket"`) the fix was identical to the input — the fix never converged and ESLint emitted `ESLintCircularFixesWarning`.

### Description of changes

Generalize the `toPascalCase` separator to any non-alphanumeric run (mirrored in both plugins), and guard the fixer: a fix is offered only when the converted value itself passes the PascalCase validation, otherwise the violation is reported without a fix. No reordering transformations (e.g. moving leading digits) are introduced.

### Description of how you validated changes

- Added invalid cases to both plugins' suites: `"my.bucket"` is fixed to `"MyBucket"` (asserted via `output`), and `"123bucket"` is reported with no fix (`output: null`).
- All pre-existing converter and rule cases stay green; `vp check` and `vp test --run` (550/550) pass.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_