### PR TITLE
fix: handle parameter property and default value props forms consistently

### DIFF
--- a/packages/eslint/src/__tests__/construct-constructor-property.test.ts
+++ b/packages/eslint/src/__tests__/construct-constructor-property.test.ts
@@ -91,6 +91,32 @@ ruleTester.run("construct-constructor-property", constructConstructorProperty, {
       `,
     },
     {
+      name: 'constructor has "scope, id, props" signature with parameter property props',
+      code: `
+      class Construct {}
+      interface MyConstructProps {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, private readonly props: MyConstructProps) {
+          super(scope, id);
+        }
+      }
+      `,
+    },
+    {
+      name: 'constructor has "scope, id, props" signature with parameter property and default value props',
+      code: `
+      class Construct {}
+      interface MyConstructProps {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, private readonly props: MyConstructProps = {}) {
+          super(scope, id);
+        }
+      }
+      `,
+    },
+    {
       name: 'constructor has more than 3 parameters but first three are "scope, id, props"',
       code: `
       class Construct {}

--- a/packages/eslint/src/__tests__/no-unused-props.test.ts
+++ b/packages/eslint/src/__tests__/no-unused-props.test.ts
@@ -527,6 +527,45 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       }
       `,
     },
+    {
+      name: "Parameter property props: all properties are used via this.props",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, private readonly props: MyConstructProps) {
+          super(scope, id);
+          console.log(this.props.bucketName, this.props.enableVersioning);
+        }
+      }
+      `,
+    },
+    {
+      name: "Parameter property props: all properties are used in another method via this.props",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, private readonly props: MyConstructProps) {
+          super(scope, id);
+        }
+
+        private log() {
+          console.log(this.props.bucketName, this.props.enableVersioning);
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {
@@ -836,6 +875,45 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       }
       `,
       errors: [{ messageId: "unusedProp" }],
+    },
+    {
+      name: "Parameter property props: some properties are unused",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+        unusedProp: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, private readonly props: MyConstructProps) {
+          super(scope, id);
+          console.log(this.props.bucketName, this.props.enableVersioning);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "Default value props: some properties are unused",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        unusedProp: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps = {} as MyConstructProps) {
+          super(scope, id);
+          console.log(props.bucketName);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
     },
   ],
 });

--- a/packages/eslint/src/__tests__/props-name-convention.test.ts
+++ b/packages/eslint/src/__tests__/props-name-convention.test.ts
@@ -50,6 +50,34 @@ ruleTester.run("props-name-convention", propsNameConvention, {
         }
       `,
     },
+    {
+      // WHEN: props parameter is a parameter property with a valid interface name
+      code: `
+        class Construct {}
+        interface MyConstructProps {
+          readonly bucket?: string;
+        }
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string, private readonly props: MyConstructProps) {
+            super(scope, id);
+          }
+        }
+      `,
+    },
+    {
+      // WHEN: props parameter has a default value with a valid interface name
+      code: `
+        class Construct {}
+        interface MyConstructProps {
+          readonly bucket?: string;
+        }
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string, props: MyConstructProps = {}) {
+            super(scope, id);
+          }
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -108,6 +136,52 @@ ruleTester.run("props-name-convention", propsNameConvention, {
         }
         class MyConstruct extends Construct {
           constructor(scope: Construct, id: string, props: WrongProps) {
+            super(scope, id);
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidPropsName",
+          data: {
+            interfaceName: "WrongProps",
+            expectedName: "MyConstructProps",
+          },
+        },
+      ],
+    },
+    {
+      // WHEN: parameter property props has a wrong interface name
+      code: `
+        class Construct {}
+        interface WrongProps {
+          readonly bucket?: string;
+        }
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string, private readonly props: WrongProps) {
+            super(scope, id);
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidPropsName",
+          data: {
+            interfaceName: "WrongProps",
+            expectedName: "MyConstructProps",
+          },
+        },
+      ],
+    },
+    {
+      // WHEN: default value props has a wrong interface name
+      code: `
+        class Construct {}
+        interface WrongProps {
+          readonly bucket?: string;
+        }
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string, props: WrongProps = {}) {
             super(scope, id);
           }
         }

--- a/packages/eslint/src/core/ast-node/finder/constructor-param-identifier.ts
+++ b/packages/eslint/src/core/ast-node/finder/constructor-param-identifier.ts
@@ -1,0 +1,18 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+
+/**
+ * Unwraps a constructor parameter (TSParameterProperty and/or AssignmentPattern layers)
+ * to its inner Identifier binding, or undefined if the binding is not a plain Identifier
+ * (e.g. ObjectPattern, ArrayPattern).
+ */
+export const findConstructorParamIdentifier = (
+  param: TSESTree.Parameter,
+): TSESTree.Identifier | undefined => {
+  const withoutParameterProperty =
+    param.type === AST_NODE_TYPES.TSParameterProperty ? param.parameter : param;
+  const withoutDefaultValue =
+    withoutParameterProperty.type === AST_NODE_TYPES.AssignmentPattern
+      ? withoutParameterProperty.left
+      : withoutParameterProperty;
+  return withoutDefaultValue.type === AST_NODE_TYPES.Identifier ? withoutDefaultValue : undefined;
+};

--- a/packages/eslint/src/rules/construct-constructor-property.ts
+++ b/packages/eslint/src/rules/construct-constructor-property.ts
@@ -7,6 +7,7 @@ import {
 } from "@typescript-eslint/utils";
 
 import { findConstructor } from "../core/ast-node/finder/constructor";
+import { findConstructorParamIdentifier } from "../core/ast-node/finder/constructor-param-identifier";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
@@ -85,12 +86,6 @@ const checkNumOfConstructorProperty = (
 };
 
 /**
- * Unwraps a parameter with a default value (e.g. `props: MyConstructProps = {}`) to its binding
- */
-const unwrapDefaultValue = (param: TSESTree.Parameter): TSESTree.Parameter =>
-  param.type === AST_NODE_TYPES.AssignmentPattern ? param.left : param;
-
-/**
  * Checks if the first parameter is named "scope" and of type Construct
  */
 const checkFirstParamIsScope = (
@@ -98,8 +93,8 @@ const checkFirstParamIsScope = (
   context: Context,
   parserServices: ParserServicesWithTypeInformation,
 ) => {
-  const binding = unwrapDefaultValue(firstParam);
-  if (binding.type !== AST_NODE_TYPES.Identifier || binding.name !== "scope") {
+  const binding = findConstructorParamIdentifier(firstParam);
+  if (!binding || binding.name !== "scope") {
     context.report({
       node: firstParam,
       messageId: "invalidConstructorProperty",
@@ -116,8 +111,8 @@ const checkFirstParamIsScope = (
  * Checks if the second parameter is named "id" and of type string
  */
 const checkSecondParamIsId = (secondParam: ConstructorProperties[1], context: Context) => {
-  const binding = unwrapDefaultValue(secondParam);
-  if (binding.type !== AST_NODE_TYPES.Identifier || binding.name !== "id") {
+  const binding = findConstructorParamIdentifier(secondParam);
+  if (!binding || binding.name !== "id") {
     context.report({
       node: secondParam,
       messageId: "invalidConstructorProperty",
@@ -135,8 +130,8 @@ const checkSecondParamIsId = (secondParam: ConstructorProperties[1], context: Co
  */
 const checkThirdParamIsProps = (thirdParam: ConstructorProperties[2], context: Context) => {
   if (!thirdParam) return;
-  const binding = unwrapDefaultValue(thirdParam);
-  if (binding.type !== AST_NODE_TYPES.Identifier || binding.name !== "props") {
+  const binding = findConstructorParamIdentifier(thirdParam);
+  if (!binding || binding.name !== "props") {
     context.report({
       node: thirdParam,
       messageId: "invalidConstructorProperty",

--- a/packages/eslint/src/rules/no-unused-props/index.ts
+++ b/packages/eslint/src/rules/no-unused-props/index.ts
@@ -8,12 +8,20 @@ import {
 import { Type } from "typescript";
 
 import { findConstructor } from "../../core/ast-node/finder/constructor";
+import { findConstructorParamIdentifier } from "../../core/ast-node/finder/constructor-param-identifier";
 import { isConstructType } from "../../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../../shared/create-rule";
 import { PropsUsageAnalyzer } from "./props-usage-analyzer";
 import { IPropsUsageTracker, PropsUsageTracker } from "./props-usage-tracker";
 
 type Context = TSESLint.RuleContext<"unusedProp", []>;
+
+type PropsParam = {
+  identifier: TSESTree.Identifier;
+  reportNode: TSESTree.Parameter;
+  type: Type;
+  isParameterProperty: boolean;
+};
 
 /**
  * Enforces that all properties defined in props type are used within the constructor
@@ -49,13 +57,15 @@ export const noUnusedProps = createRule({
 
         const propsParam = getPropsParam(constructor, parserServices);
         if (!propsParam) return;
-        if (isPropsUsedInSuperCall(constructor, propsParam.node.name)) return;
+        if (isPropsUsedInSuperCall(constructor, propsParam.identifier.name)) return;
 
         const tracker = new PropsUsageTracker(propsParam.type);
         const analyzer = new PropsUsageAnalyzer(tracker);
 
-        analyzer.analyze(constructor, propsParam.node);
-        reportUnusedProperties(tracker, propsParam.node, context);
+        analyzer.analyze(constructor, propsParam.identifier.name, {
+          treatAsInstanceVariable: propsParam.isParameterProperty,
+        });
+        reportUnusedProperties(tracker, propsParam.reportNode, context);
       },
     };
   },
@@ -64,20 +74,24 @@ export const noUnusedProps = createRule({
 const getPropsParam = (
   constructor: TSESTree.MethodDefinition,
   parserServices: ParserServicesWithTypeInformation,
-): { node: TSESTree.Identifier; type: Type } | null => {
+): PropsParam | null => {
   const params = constructor.value.params;
   if (params.length < 3) return null;
 
   const propsParam = params[2];
+  const isParameterProperty = propsParam.type === AST_NODE_TYPES.TSParameterProperty;
 
   // ++++++++++++++Important+++++++++++++
   // When AST_NODE_TYPES is "ObjectPattern" (e.g. { bucketName, enableVersioning }: MyConstructProps), it can be confirmed whether the variable is used in the IDE, and it conflicts with the @typescript-eslint/no-unused-vars rule, so this rule does not apply.
   // ++++++++++++++++++++++++++++++++++++
-  if (propsParam.type !== AST_NODE_TYPES.Identifier) return null;
+  const identifier = findConstructorParamIdentifier(propsParam);
+  if (!identifier) return null;
 
   return {
-    node: propsParam,
-    type: parserServices.getTypeAtLocation(propsParam),
+    identifier,
+    reportNode: propsParam,
+    type: parserServices.getTypeAtLocation(identifier),
+    isParameterProperty,
   };
 };
 

--- a/packages/eslint/src/rules/no-unused-props/props-usage-analyzer.ts
+++ b/packages/eslint/src/rules/no-unused-props/props-usage-analyzer.ts
@@ -10,7 +10,20 @@ import {
 } from "./visitor";
 
 export interface IPropsUsageAnalyzer {
-  analyze(constructor: TSESTree.MethodDefinition, propsParam: TSESTree.Identifier): void;
+  analyze(
+    constructor: TSESTree.MethodDefinition,
+    propsParamName: string,
+    options?: AnalyzeOptions,
+  ): void;
+}
+
+export interface AnalyzeOptions {
+  /**
+   * When true, `this.<propsParamName>` is treated as a props instance variable in addition to
+   * regular usage tracking. This is used for parameter property forms where the constructor
+   * parameter `props` is also auto-assigned to `this.props` by TypeScript.
+   */
+  treatAsInstanceVariable?: boolean;
 }
 
 export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
@@ -20,10 +33,13 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
     this.tracker = tracker;
   }
 
-  analyze(constructor: TSESTree.MethodDefinition, propsParam: TSESTree.Identifier): void {
+  analyze(
+    constructor: TSESTree.MethodDefinition,
+    propsParamName: string,
+    options: AnalyzeOptions = {},
+  ): void {
     const constructorBody = constructor.value.body;
     const classNode = constructor.parent;
-    const propsParamName = propsParam.name;
     if (!constructorBody) return;
 
     this.checkUsageForDirectAccess(constructorBody, propsParamName);
@@ -34,6 +50,18 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
       classNode,
       propsParamName,
     );
+    if (options.treatAsInstanceVariable) {
+      this.checkUsageForBoundInstanceVariable(classNode, propsParamName);
+    }
+  }
+
+  /**
+   * Tracks usage through `this.<name>` for parameter-property-declared props, where
+   * TypeScript implicitly assigns the parameter to an instance field of the same name.
+   */
+  private checkUsageForBoundInstanceVariable(classBody: TSESTree.ClassBody, name: string): void {
+    const visitor = new InstanceVariableUsageVisitor(this.tracker, name);
+    traverseNodes(classBody, visitor);
   }
 
   /**

--- a/packages/eslint/src/rules/props-name-convention.ts
+++ b/packages/eslint/src/rules/props-name-convention.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 import { findConstructor } from "../core/ast-node/finder/constructor";
+import { findConstructorParamIdentifier } from "../core/ast-node/finder/constructor-param-identifier";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
@@ -37,9 +38,12 @@ export const propsNameConvention = createRule({
         if (!constructor) return;
 
         const propsParam = constructor.value.params?.[2];
-        if (propsParam?.type !== AST_NODE_TYPES.Identifier) return;
+        if (!propsParam) return;
 
-        const typeAnnotation = propsParam.typeAnnotation;
+        const binding = findConstructorParamIdentifier(propsParam);
+        if (!binding) return;
+
+        const typeAnnotation = binding.typeAnnotation;
         if (typeAnnotation?.type !== AST_NODE_TYPES.TSTypeAnnotation) return;
 
         const typeNode = typeAnnotation.typeAnnotation;

--- a/packages/oxlint/src/__tests__/construct-constructor-property.test.ts
+++ b/packages/oxlint/src/__tests__/construct-constructor-property.test.ts
@@ -92,6 +92,30 @@ ruleTester.run("construct-constructor-property", constructConstructorProperty, {
     },
     {
       code: `
+      class Construct {}
+      interface MyConstructProps {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, private readonly props: MyConstructProps) {
+          super(scope, id);
+        }
+      }
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      interface MyConstructProps {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, private readonly props: MyConstructProps = {}) {
+          super(scope, id);
+        }
+      }
+      `,
+    },
+    {
+      code: `
       export class MyConstruct {
         constructor(invalidProperty: any) {}
       }

--- a/packages/oxlint/src/__tests__/no-unused-props.test.ts
+++ b/packages/oxlint/src/__tests__/no-unused-props.test.ts
@@ -521,6 +521,45 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       }
       `,
     },
+    {
+      name: "Parameter property props: all properties are used via this.props",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, private readonly props: MyConstructProps) {
+          super(scope, id);
+          console.log(this.props.bucketName, this.props.enableVersioning);
+        }
+      }
+      `,
+    },
+    {
+      name: "Parameter property props: all properties are used in another method via this.props",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, private readonly props: MyConstructProps) {
+          super(scope, id);
+        }
+
+        private log() {
+          console.log(this.props.bucketName, this.props.enableVersioning);
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {
@@ -830,6 +869,45 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       }
       `,
       errors: [{ messageId: "unusedProp" }],
+    },
+    {
+      name: "Parameter property props: some properties are unused",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+        unusedProp: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, private readonly props: MyConstructProps) {
+          super(scope, id);
+          console.log(this.props.bucketName, this.props.enableVersioning);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "Default value props: some properties are unused",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        unusedProp: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps = {} as MyConstructProps) {
+          super(scope, id);
+          console.log(props.bucketName);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
     },
   ],
 });

--- a/packages/oxlint/src/__tests__/props-name-convention.test.ts
+++ b/packages/oxlint/src/__tests__/props-name-convention.test.ts
@@ -44,6 +44,34 @@ ruleTester.run("props-name-convention", propsNameConvention, {
         }
       `,
     },
+    {
+      // WHEN: props parameter is a parameter property with a valid interface name
+      code: `
+        class Construct {}
+        interface MyConstructProps {
+          readonly bucket?: string;
+        }
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string, private readonly props: MyConstructProps) {
+            super(scope, id);
+          }
+        }
+      `,
+    },
+    {
+      // WHEN: props parameter has a default value with a valid interface name
+      code: `
+        class Construct {}
+        interface MyConstructProps {
+          readonly bucket?: string;
+        }
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string, props: MyConstructProps = {}) {
+            super(scope, id);
+          }
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -102,6 +130,52 @@ ruleTester.run("props-name-convention", propsNameConvention, {
         }
         class MyConstruct extends Construct {
           constructor(scope: Construct, id: string, props: WrongProps) {
+            super(scope, id);
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidPropsName",
+          data: {
+            interfaceName: "WrongProps",
+            expectedName: "MyConstructProps",
+          },
+        },
+      ],
+    },
+    {
+      // WHEN: parameter property props has a wrong interface name
+      code: `
+        class Construct {}
+        interface WrongProps {
+          readonly bucket?: string;
+        }
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string, private readonly props: WrongProps) {
+            super(scope, id);
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidPropsName",
+          data: {
+            interfaceName: "WrongProps",
+            expectedName: "MyConstructProps",
+          },
+        },
+      ],
+    },
+    {
+      // WHEN: default value props has a wrong interface name
+      code: `
+        class Construct {}
+        interface WrongProps {
+          readonly bucket?: string;
+        }
+        class MyConstruct extends Construct {
+          constructor(scope: Construct, id: string, props: WrongProps = {}) {
             super(scope, id);
           }
         }

--- a/packages/oxlint/src/core/ast-node/finder/constructor-param-identifier.ts
+++ b/packages/oxlint/src/core/ast-node/finder/constructor-param-identifier.ts
@@ -1,0 +1,18 @@
+import type { ESTree } from "corsa-oxlint";
+
+import { AST_NODE_TYPES } from "corsa-oxlint";
+
+/**
+ * Unwraps a constructor parameter (TSParameterProperty and/or AssignmentPattern layers)
+ * to its inner Identifier binding, or undefined if the binding is not a plain Identifier
+ * (e.g. ObjectPattern, ArrayPattern).
+ */
+export const findConstructorParamIdentifier = (param: ESTree.Node) => {
+  const withoutParameterProperty =
+    param.type === AST_NODE_TYPES.TSParameterProperty ? param.parameter : param;
+  const withoutDefaultValue =
+    withoutParameterProperty.type === AST_NODE_TYPES.AssignmentPattern
+      ? withoutParameterProperty.left
+      : withoutParameterProperty;
+  return withoutDefaultValue.type === AST_NODE_TYPES.Identifier ? withoutDefaultValue : undefined;
+};

--- a/packages/oxlint/src/rules/construct-constructor-property.ts
+++ b/packages/oxlint/src/rules/construct-constructor-property.ts
@@ -3,6 +3,7 @@ import type { ESTree, ParserServices, RuleContext } from "corsa-oxlint";
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findConstructor } from "../core/ast-node/finder/constructor";
+import { findConstructorParamIdentifier } from "../core/ast-node/finder/constructor-param-identifier";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
@@ -80,12 +81,6 @@ const checkNumOfConstructorProperty = (
 };
 
 /**
- * Unwraps a parameter with a default value (e.g. `props: MyConstructProps = {}`) to its binding
- */
-const unwrapDefaultValue = (param: ConstructorParam) =>
-  param.type === AST_NODE_TYPES.AssignmentPattern ? param.left : param;
-
-/**
  * Checks if the first parameter is named "scope" and of type Construct
  */
 const checkFirstParamIsScope = (
@@ -93,8 +88,8 @@ const checkFirstParamIsScope = (
   context: RuleContext,
   parserServices: ParserServices,
 ) => {
-  const binding = unwrapDefaultValue(firstParam);
-  if (binding.type !== AST_NODE_TYPES.Identifier || binding.name !== "scope") {
+  const binding = findConstructorParamIdentifier(firstParam);
+  if (!binding || binding.name !== "scope") {
     context.report({
       node: firstParam,
       messageId: "invalidConstructorProperty",
@@ -116,8 +111,8 @@ const checkFirstParamIsScope = (
  * Checks if the second parameter is named "id" and of type string
  */
 const checkSecondParamIsId = (secondParam: ConstructorProperties[1], context: RuleContext) => {
-  const binding = unwrapDefaultValue(secondParam);
-  if (binding.type !== AST_NODE_TYPES.Identifier || binding.name !== "id") {
+  const binding = findConstructorParamIdentifier(secondParam);
+  if (!binding || binding.name !== "id") {
     context.report({
       node: secondParam,
       messageId: "invalidConstructorProperty",
@@ -135,8 +130,8 @@ const checkSecondParamIsId = (secondParam: ConstructorProperties[1], context: Ru
  */
 const checkThirdParamIsProps = (thirdParam: ConstructorProperties[2], context: RuleContext) => {
   if (!thirdParam) return;
-  const binding = unwrapDefaultValue(thirdParam);
-  if (binding.type !== AST_NODE_TYPES.Identifier || binding.name !== "props") {
+  const binding = findConstructorParamIdentifier(thirdParam);
+  if (!binding || binding.name !== "props") {
     context.report({
       node: thirdParam,
       messageId: "invalidConstructorProperty",

--- a/packages/oxlint/src/rules/no-unused-props/index.ts
+++ b/packages/oxlint/src/rules/no-unused-props/index.ts
@@ -1,8 +1,9 @@
-import type { CorsaType, ESTree, ParserServices, RuleContext } from "corsa-oxlint";
+import type { ESTree, ParserServices, RuleContext } from "corsa-oxlint";
 
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findConstructor } from "../../core/ast-node/finder/constructor";
+import { findConstructorParamIdentifier } from "../../core/ast-node/finder/constructor-param-identifier";
 import { isConstructType } from "../../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../../shared/create-rule";
 import { PropsUsageAnalyzer } from "./props-usage-analyzer";
@@ -42,38 +43,41 @@ export const noUnusedProps = createRule({
 
         const propsParam = getPropsParam(constructor, parserServices);
         if (!propsParam) return;
-        if (isPropsUsedInSuperCall(constructor, propsParam.node.name)) return;
+        if (isPropsUsedInSuperCall(constructor, propsParam.identifier.name)) return;
 
         const tracker = new PropsUsageTracker(propsParam.type, checker);
         const analyzer = new PropsUsageAnalyzer(tracker);
 
-        analyzer.analyze(constructor, propsParam.node);
-        reportUnusedProperties(tracker, propsParam.node, context);
+        analyzer.analyze(constructor, propsParam.identifier.name, {
+          treatAsInstanceVariable: propsParam.isParameterProperty,
+        });
+        reportUnusedProperties(tracker, propsParam.reportNode, context);
       },
     };
   },
 });
 
-const getPropsParam = (
-  constructor: ESTree.MethodDefinition,
-  parserServices: ParserServices,
-): { node: ESTree.BindingIdentifier; type: CorsaType } | null => {
+const getPropsParam = (constructor: ESTree.MethodDefinition, parserServices: ParserServices) => {
   const params = constructor.value.params;
   if (params.length < 3) return null;
 
   const propsParam = params[2];
+  const isParameterProperty = propsParam.type === AST_NODE_TYPES.TSParameterProperty;
 
   // ++++++++++++++Important+++++++++++++
   // When AST_NODE_TYPES is "ObjectPattern" (e.g. { bucketName, enableVersioning }: MyConstructProps), it can be confirmed whether the variable is used in the IDE, and it conflicts with the @typescript-eslint/no-unused-vars rule, so this rule does not apply.
   // ++++++++++++++++++++++++++++++++++++
-  if (propsParam.type !== AST_NODE_TYPES.Identifier) return null;
+  const identifier = findConstructorParamIdentifier(propsParam);
+  if (!identifier) return null;
 
-  const type = parserServices.getTypeAtLocation(propsParam);
+  const type = parserServices.getTypeAtLocation(identifier);
   if (!type) return null;
 
   return {
-    node: propsParam,
+    identifier,
+    reportNode: propsParam,
     type,
+    isParameterProperty,
   };
 };
 
@@ -129,7 +133,7 @@ const isPropsUsedInSuperCall = (
  */
 const reportUnusedProperties = (
   tracker: IPropsUsageTracker,
-  propsParam: ESTree.BindingIdentifier,
+  propsParam: ESTree.Node,
   context: RuleContext,
 ): void => {
   for (const propName of tracker.getUnusedProperties()) {

--- a/packages/oxlint/src/rules/no-unused-props/props-usage-analyzer.ts
+++ b/packages/oxlint/src/rules/no-unused-props/props-usage-analyzer.ts
@@ -12,7 +12,20 @@ import {
 } from "./visitor";
 
 export interface IPropsUsageAnalyzer {
-  analyze(constructor: ESTree.MethodDefinition, propsParam: ESTree.BindingIdentifier): void;
+  analyze(
+    constructor: ESTree.MethodDefinition,
+    propsParamName: string,
+    options?: AnalyzeOptions,
+  ): void;
+}
+
+export interface AnalyzeOptions {
+  /**
+   * When true, `this.<propsParamName>` is treated as a props instance variable in addition to
+   * regular usage tracking. This is used for parameter property forms where the constructor
+   * parameter `props` is also auto-assigned to `this.props` by TypeScript.
+   */
+  treatAsInstanceVariable?: boolean;
 }
 
 export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
@@ -22,10 +35,13 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
     this.tracker = tracker;
   }
 
-  analyze(constructor: ESTree.MethodDefinition, propsParam: ESTree.BindingIdentifier): void {
+  analyze(
+    constructor: ESTree.MethodDefinition,
+    propsParamName: string,
+    options: AnalyzeOptions = {},
+  ): void {
     const constructorBody = constructor.value.body;
     const classNode = constructor.parent;
-    const propsParamName = propsParam.name;
     if (!constructorBody) return;
     if (!classNode || classNode.type !== AST_NODE_TYPES.ClassBody) return;
 
@@ -37,6 +53,18 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
       classNode,
       propsParamName,
     );
+    if (options.treatAsInstanceVariable) {
+      this.checkUsageForBoundInstanceVariable(classNode, propsParamName);
+    }
+  }
+
+  /**
+   * Tracks usage through `this.<name>` for parameter-property-declared props, where
+   * TypeScript implicitly assigns the parameter to an instance field of the same name.
+   */
+  private checkUsageForBoundInstanceVariable(classBody: ESTree.ClassBody, name: string): void {
+    const visitor = new InstanceVariableUsageVisitor(this.tracker, name);
+    traverseNodes(classBody, visitor);
   }
 
   /**

--- a/packages/oxlint/src/rules/props-name-convention.ts
+++ b/packages/oxlint/src/rules/props-name-convention.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findConstructor } from "../core/ast-node/finder/constructor";
+import { findConstructorParamIdentifier } from "../core/ast-node/finder/constructor-param-identifier";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
@@ -37,9 +38,12 @@ export const propsNameConvention = createRule({
         if (!constructor) return;
 
         const propsParam = constructor.value.params?.[2];
-        if (propsParam?.type !== AST_NODE_TYPES.Identifier) return;
+        if (!propsParam) return;
 
-        const typeAnnotation = propsParam.typeAnnotation;
+        const binding = findConstructorParamIdentifier(propsParam);
+        if (!binding) return;
+
+        const typeAnnotation = binding.typeAnnotation;
         if (typeAnnotation?.type !== AST_NODE_TYPES.TSTypeAnnotation) return;
 
         const typeNode = typeAnnotation.typeAnnotation;


### PR DESCRIPTION
### Issue # (if applicable)

Closes #534.

### Reason for this change

The three props-related rules handled non-plain-identifier `props` parameters (parameter property `private readonly props: XProps`, default value `props: XProps = {}`) inconsistently: `construct-constructor-property` reported a false positive for the parameter property form (with a misleading naming message), while `props-name-convention` and `no-unused-props` silently skipped both forms entirely.

### Description of changes

Add a `findConstructorParamIdentifier` finder (mirrored in both plugins) that unwraps `TSParameterProperty` and/or `AssignmentPattern` layers to the underlying identifier, and use it in all three rules so both forms are treated as regular props parameters. For the parameter property form, `no-unused-props` additionally tracks `this.<name>.xxx` usages by reusing the existing instance-variable visitor, since TypeScript implicitly assigns the parameter to an instance field. Bare-identifier semantics (including the intentional `ObjectPattern` exclusion) are unchanged; the usage-tracking gaps of #532 are out of scope here.

### Description of how you validated changes

- Added valid / invalid cases for both forms to all three rules' suites in both plugins (20 new cases), covering the three repros from the issue: parameter property is no longer reported by `construct-constructor-property`, wrong interface names are now reported for both forms, and unused properties are reported with usage tracked through `this.props`.
- `vp check` and `vp test --run` (572/572) pass.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_