### PR TITLE
fix: treat whole-props escapes as full usage in no-unused-props

### DIFF
--- a/packages/eslint/src/__tests__/no-unused-props.test.ts
+++ b/packages/eslint/src/__tests__/no-unused-props.test.ts
@@ -756,6 +756,144 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       }
       `,
     },
+    {
+      name: "Props is passed to an inherited method (unresolved) — treated as whole usage",
+      code: `
+      class Construct {
+        protected inheritedHelper(_props: unknown): void {}
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.inheritedHelper(props);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is passed via computed this-call — treated as whole usage",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this["setup"](props);
+        }
+        private setup(p: MyConstructProps) {
+          console.log(p.bucketName);
+        }
+      }
+      `,
+    },
+    {
+      name: "Alias is passed to a this-method — treated as whole usage of the alias",
+      code: `
+      class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: any) { super(scope, id); }
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          const bucketProps = props;
+          this.store(bucketProps);
+        }
+        private store(p: unknown) {
+          console.log(p);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is assigned to instance field inside a conditional and read elsewhere",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        #props?: MyConstructProps;
+        constructor(scope: Construct, id: string, props: MyConstructProps, condition: boolean) {
+          super(scope, id);
+          if (condition) {
+            this.#props = props;
+          }
+        }
+        log() {
+          console.log(this.#props?.bucketName, this.#props?.enableVersioning);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is assigned to multiple instance fields and every field is read",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        private a?: MyConstructProps;
+        private b?: MyConstructProps;
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.a = props;
+          this.b = props;
+        }
+        log() {
+          console.log(this.a?.bucketName);
+          console.log(this.b?.enableVersioning);
+        }
+      }
+      `,
+    },
+    {
+      name: "Same method is called with props at two different arg positions",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.m(props, {} as MyConstructProps);
+          this.m({} as MyConstructProps, props);
+        }
+        private m(first: MyConstructProps, second: MyConstructProps) {
+          console.log(first.bucketName);
+          console.log(second.enableVersioning);
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {
@@ -1148,6 +1286,29 @@ ruleTester.run("no-unused-props", noUnusedProps, {
         }
         private createBucket(p: MyConstructProps) {
           new Bucket(this, "B", { bucketName: p.bucketName, versioned: p.enableVersioning });
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "Instance-variable binding still reports properties that no method reads",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        unusedProp: string;
+      }
+
+      export class MyConstruct extends Construct {
+        private myProps: MyConstructProps;
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.myProps = props;
+        }
+        log() {
+          console.log(this.myProps.bucketName);
         }
       }
       `,

--- a/packages/eslint/src/__tests__/no-unused-props.test.ts
+++ b/packages/eslint/src/__tests__/no-unused-props.test.ts
@@ -566,6 +566,196 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       }
       `,
     },
+    {
+      name: "Props is passed as whole to NewExpression argument",
+      code: `
+      class Construct {}
+      class Queue extends Construct {
+        constructor(scope: Construct, id: string, props: any) { super(scope, id); }
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          new Queue(this, "Queue", props);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is spread into a NewExpression argument object",
+      code: `
+      class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: any) { super(scope, id); }
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          new Bucket(this, "Dest", { ...props, extra: true });
+        }
+      }
+      `,
+    },
+    {
+      name: "Props alias is passed as a whole to a NewExpression argument",
+      code: `
+      class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: any) { super(scope, id); }
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          const bucketProps = props;
+          new Bucket(this, "Dest", bucketProps);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is queried via 'in' operator",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        encryption: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          if ("encryption" in props) {
+            console.log("encrypted");
+          }
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is destructured with a rest element",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        logPrefix: string;
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          const { logPrefix, ...bucketProps } = props;
+          console.log(logPrefix, bucketProps);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is accessed via string literal computed key",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          console.log(props["bucketName"], props["enableVersioning"]);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is accessed via a variable computed key (treated as whole usage)",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          const key: keyof MyConstructProps = "bucketName";
+          console.log(props[key]);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is assigned to a private field via # and its properties are used",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      class MyConstruct extends Construct {
+        #props: MyConstructProps;
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.#props = props;
+        }
+        log() {
+          console.log(this.#props.bucketName, this.#props.enableVersioning);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is passed transitively through two private methods",
+      code: `
+      class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: any) { super(scope, id); }
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.setup(props);
+        }
+        private setup(p: MyConstructProps) {
+          this.createBucket(p);
+        }
+        private createBucket(p: MyConstructProps) {
+          new Bucket(this, "B", { bucketName: p.bucketName, versioned: p.enableVersioning });
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {
@@ -910,6 +1100,54 @@ ruleTester.run("no-unused-props", noUnusedProps, {
         constructor(scope: Construct, id: string, props: MyConstructProps = {} as MyConstructProps) {
           super(scope, id);
           console.log(props.bucketName);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "String literal computed access reports only untouched properties",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          console.log(props["bucketName"]);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "enableVersioning" } }],
+    },
+    {
+      name: "Transitive method chain still reports properties never referenced",
+      code: `
+      class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: any) { super(scope, id); }
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+        unusedProp: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.setup(props);
+        }
+        private setup(p: MyConstructProps) {
+          this.createBucket(p);
+        }
+        private createBucket(p: MyConstructProps) {
+          new Bucket(this, "B", { bucketName: p.bucketName, versioned: p.enableVersioning });
         }
       }
       `,

--- a/packages/eslint/src/rules/no-unused-props/props-usage-analyzer.ts
+++ b/packages/eslint/src/rules/no-unused-props/props-usage-analyzer.ts
@@ -26,6 +26,11 @@ export interface AnalyzeOptions {
   treatAsInstanceVariable?: boolean;
 }
 
+type InstanceVarBinding = {
+  name: string;
+  isPrivateField: boolean;
+};
+
 export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
   private readonly tracker: IPropsUsageTracker;
 
@@ -42,183 +47,75 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
     const classNode = constructor.parent;
     if (!constructorBody) return;
 
-    this.checkUsageForDirectAccess(constructorBody, propsParamName);
-    this.checkUsageForAliasAccess(constructorBody, propsParamName);
-    this.checkUsageForInstanceVariable(classNode, constructor, propsParamName);
-    this.checkUsageForPrivateMethodsCalledFromConstructor(
-      constructorBody,
-      classNode,
-      propsParamName,
-    );
+    this.analyzeBlockForBinding(constructorBody, propsParamName);
+    this.checkUsageForInstanceVariable(classNode, constructorBody, propsParamName);
+    this.analyzeTransitiveMethodCalls(constructorBody, classNode, propsParamName, new Set());
     if (options.treatAsInstanceVariable) {
-      this.checkUsageForBoundInstanceVariable(classNode, propsParamName);
+      const visitor = new InstanceVariableUsageVisitor(this.tracker, propsParamName);
+      traverseNodes(classNode, visitor);
     }
   }
 
   /**
-   * Tracks usage through `this.<name>` for parameter-property-declared props, where
-   * TypeScript implicitly assigns the parameter to an instance field of the same name.
+   * Runs the direct-usage and alias visitors over a block (constructor body or a method body
+   * reached transitively via `this.method(props)`).
    */
-  private checkUsageForBoundInstanceVariable(classBody: TSESTree.ClassBody, name: string): void {
-    const visitor = new InstanceVariableUsageVisitor(this.tracker, name);
+  private analyzeBlockForBinding(block: TSESTree.BlockStatement, paramName: string): void {
+    const directVisitor = new DirectPropsUsageVisitor(this.tracker, paramName);
+    traverseNodes(block, directVisitor);
+
+    const aliasVisitor = new PropsAliasVisitor(this.tracker, paramName);
+    traverseNodes(block, aliasVisitor);
+  }
+
+  /**
+   * Tracks `this.<field> = props` bindings and scans the whole class for reads of that field.
+   * Handles both `Identifier` (`this.myProps`) and `PrivateIdentifier` (`this.#myProps`).
+   */
+  private checkUsageForInstanceVariable(
+    classBody: TSESTree.ClassBody,
+    constructorBody: TSESTree.BlockStatement,
+    propsParamName: string,
+  ): void {
+    const binding = this.findPropsInstanceVariable(constructorBody, propsParamName);
+    if (!binding) return;
+
+    const visitor = new InstanceVariableUsageVisitor(
+      this.tracker,
+      binding.name,
+      binding.isPrivateField,
+    );
     traverseNodes(classBody, visitor);
   }
 
   /**
-   * Analyzes direct access to props within the constructor body.
-   *
-   * @example
-   * ```typescript
-   * constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *   super(scope, id);
-   *   console.log(props.bucketName);  // <- Direct access tracked here
-   * }
-   * ```
-   *
-   * @param constructorBody - The constructor's BlockStatement to analyze
-   * @param propsParamName - The name of the props parameter (e.g., "props")
+   * Follows `this.method(props)` chains from the constructor into method bodies (and further
+   * into any methods those bodies call). A visited set keyed by MethodDefinition node prevents
+   * infinite loops on recursive methods.
    */
-  private checkUsageForDirectAccess(
-    constructorBody: TSESTree.BlockStatement,
-    propsParamName: string,
-  ): void {
-    const directVisitor = new DirectPropsUsageVisitor(this.tracker, propsParamName);
-    traverseNodes(constructorBody, directVisitor);
-  }
-
-  /**
-   * Analyzes props usage via aliases within the constructor body.
-   *
-   * When props is assigned to another variable (alias), this method tracks
-   * usage of that alias throughout the constructor.
-   *
-   * @example
-   * ```typescript
-   * constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *   super(scope, id);
-   *   const p = props;  // <- Alias assignment detected
-   *   console.log(p.bucketName);  // <- Usage tracked here
-   * }
-   * ```
-   *
-   * @param constructorBody - The constructor's BlockStatement to analyze
-   * @param propsParamName - The name of the props parameter (e.g., "props")
-   */
-  private checkUsageForAliasAccess(
-    constructorBody: TSESTree.BlockStatement,
-    propsParamName: string,
-  ): void {
-    const aliasVisitor = new PropsAliasVisitor(this.tracker, propsParamName);
-    traverseNodes(constructorBody, aliasVisitor);
-  }
-
-  /**
-   * Analyzes the class body for props usage via instance variables.
-   *
-   * When props is assigned to an instance variable (e.g., `this.myProps = props`),
-   * this method tracks usage of that instance variable throughout the entire class.
-   *
-   * @example
-   * ```typescript
-   * class MyConstruct extends Construct {
-   *   private myProps: MyConstructProps;
-   *
-   *   constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *     super(scope, id);
-   *     this.myProps = props;  // <- Instance variable assignment detected
-   *   }
-   *
-   *   someMethod() {
-   *     console.log(this.myProps.bucketName);  // <- Usage tracked here
-   *   }
-   * }
-   * ```
-   *
-   * @param classBody - The ClassBody node to analyze
-   * @param constructor - The constructor MethodDefinition node
-   * @param propsParamName - The name of the props parameter (e.g., "props")
-   */
-  private checkUsageForInstanceVariable(
+  private analyzeTransitiveMethodCalls(
+    body: TSESTree.BlockStatement,
     classBody: TSESTree.ClassBody,
-    constructor: TSESTree.MethodDefinition,
-    propsParamName: string,
-  ) {
-    if (!constructor.value.body) return;
-    const instanceVarName = this.findPropsInstanceVariable(constructor.value.body, propsParamName);
-    if (!instanceVarName) return;
-
-    const instanceVisitor = new InstanceVariableUsageVisitor(this.tracker, instanceVarName);
-    traverseNodes(classBody, instanceVisitor);
-  }
-
-  /**
-   * Analyzes private methods that are called from the constructor with props as an argument.
-   *
-   * When a constructor calls a private method and passes props to it, this method
-   * finds the method definition and analyzes the props usage within that method.
-   *
-   * @example
-   * ```typescript
-   * class MyConstruct extends Construct {
-   *   constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *     super(scope, id);
-   *     this.setupBucket(props);  // <- Method call with props detected
-   *   }
-   *
-   *   private setupBucket(p: MyConstructProps) {
-   *     // Props usage in this method body is analyzed
-   *     new Bucket(this, 'Bucket', { bucketName: p.bucketName });
-   *   }
-   * }
-   * ```
-   *
-   * @param constructorBody - The constructor's BlockStatement to search for method calls
-   * @param classBody - The ClassBody containing method definitions
-   * @param propsParamName - The name of the props parameter (e.g., "props")
-   */
-  private checkUsageForPrivateMethodsCalledFromConstructor(
-    constructorBody: TSESTree.BlockStatement,
-    classBody: TSESTree.ClassBody,
-    propsParamName: string,
+    paramName: string,
+    visited: Set<TSESTree.MethodDefinition>,
   ): void {
-    // NOTE: Collect method calls in constructor
-    const methodCallsWithProps = this.collectMethodCallsWithProps(constructorBody, propsParamName);
+    const methodCalls = this.collectMethodCallsWithProps(body, paramName);
 
-    // NOTE: For each method call, find the method definition and analyze it
-    for (const { methodName, propsArgIndices } of methodCallsWithProps) {
+    for (const { methodName, propsArgIndices } of methodCalls) {
       const methodDef = this.findMethodDefinition(classBody, methodName);
       if (!methodDef?.value.body) continue;
+      if (visited.has(methodDef)) continue;
+      visited.add(methodDef);
 
-      // NOTE: Get the actual parameter names from the method definition
       for (const argIndex of propsArgIndices) {
         const param = methodDef.value.params[argIndex];
-        if (param?.type === AST_NODE_TYPES.Identifier) {
-          const visitor = new DirectPropsUsageVisitor(this.tracker, param.name);
-          traverseNodes(methodDef.value.body, visitor);
-        }
+        if (param?.type !== AST_NODE_TYPES.Identifier) continue;
+        this.analyzeBlockForBinding(methodDef.value.body, param.name);
+        this.analyzeTransitiveMethodCalls(methodDef.value.body, classBody, param.name, visited);
       }
     }
   }
 
-  /**
-   * Collects method calls in the constructor body where props is passed as an argument.
-   *
-   * Uses `MethodCallCollectorVisitor` to traverse the constructor body and find
-   * all `this.methodName(props)` patterns.
-   *
-   * @example
-   * ```typescript
-   * constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *   super(scope, id);
-   *   this.setupBucket(props);        // <- Collected: { methodName: "setupBucket", propsArgIndices: [0] }
-   *   this.configure(config, props);  // <- Collected: { methodName: "configure", propsArgIndices: [1] }
-   * }
-   * ```
-   *
-   * @param body - The constructor's BlockStatement to traverse
-   * @param propsParamName - The name of the props parameter (e.g., "props")
-   * @returns Array of method call info with method names and argument indices where props appears
-   */
   private collectMethodCallsWithProps(
     body: TSESTree.BlockStatement,
     propsParamName: string,
@@ -229,86 +126,36 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
   }
 
   /**
-   * Finds the instance variable name where props is assigned in the constructor.
-   *
-   * This method detects the pattern where props is stored in an instance variable
-   * for later access within the class.
-   *
-   * @example
-   * ```typescript
-   * class MyConstruct extends Construct {
-   *   private myProps: MyConstructProps;
-   *
-   *   constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *     super(scope, id);
-   *     this.myProps = props;  // <- This pattern is detected
-   *   }
-   * }
-   * ```
-   *
-   * AST structure for `this.myProps = props`:
-   *   ExpressionStatement
-   *   └── expression: AssignmentExpression
-   *       ├── left: MemberExpression
-   *       │   ├── object: ThisExpression
-   *       │   └── property: Identifier (name: "myProps" - returned value)
-   *       └── right: Identifier (name: "props" === propsParamName)
-   *
-   * @param body - The constructor's BlockStatement to analyze
-   * @param propsParamName - The name of the props parameter (e.g., "props")
-   * @returns The instance variable name (e.g., "myProps") or null if not found
+   * Detects `this.<name> = props` or `this.#<name> = props` in the constructor's top-level
+   * statements. Returns the field's name and whether it is a `#`-prefixed private field.
    */
   private findPropsInstanceVariable(
     body: TSESTree.BlockStatement,
     propsParamName: string,
-  ): string | null {
+  ): InstanceVarBinding | null {
     for (const statement of body.body) {
+      if (statement.type !== AST_NODE_TYPES.ExpressionStatement) continue;
+      const expression = statement.expression;
+      if (expression.type !== AST_NODE_TYPES.AssignmentExpression) continue;
       if (
-        statement.type === AST_NODE_TYPES.ExpressionStatement &&
-        statement.expression.type === AST_NODE_TYPES.AssignmentExpression &&
-        statement.expression.left.type === AST_NODE_TYPES.MemberExpression &&
-        statement.expression.left.object.type === AST_NODE_TYPES.ThisExpression &&
-        statement.expression.left.property.type === AST_NODE_TYPES.Identifier &&
-        statement.expression.right.type === AST_NODE_TYPES.Identifier &&
-        statement.expression.right.name === propsParamName
+        expression.right.type !== AST_NODE_TYPES.Identifier ||
+        expression.right.name !== propsParamName
       ) {
-        return statement.expression.left.property.name;
+        continue;
+      }
+      const left = expression.left;
+      if (left.type !== AST_NODE_TYPES.MemberExpression) continue;
+      if (left.object.type !== AST_NODE_TYPES.ThisExpression) continue;
+      if (left.property.type === AST_NODE_TYPES.Identifier) {
+        return { name: left.property.name, isPrivateField: false };
+      }
+      if (left.property.type === AST_NODE_TYPES.PrivateIdentifier) {
+        return { name: left.property.name, isPrivateField: true };
       }
     }
     return null;
   }
 
-  /**
-   * Finds a method definition in the class body by its name.
-   *
-   * This method is used to locate the actual method implementation when
-   * a method call like `this.someMethod(props)` is found in the constructor.
-   *
-   * @example
-   * ```typescript
-   * class MyConstruct extends Construct {
-   *   constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *     super(scope, id);
-   *     this.setupBucket(props);  // <- Method call detected
-   *   }
-   *
-   *   private setupBucket(p: MyConstructProps) {  // <- This definition is found
-   *     new Bucket(this, 'Bucket', { bucketName: p.bucketName });
-   *   }
-   * }
-   * ```
-   *
-   * AST structure for method definition:
-   *   MethodDefinition
-   *   ├── key: Identifier (name: "setupBucket" === methodName)
-   *   └── value: FunctionExpression
-   *       ├── params: [Identifier, ...]
-   *       └── body: BlockStatement
-   *
-   * @param classBody - The ClassBody node containing all class members
-   * @param methodName - The name of the method to find (e.g., "setupBucket")
-   * @returns The MethodDefinition node or null if not found
-   */
   private findMethodDefinition(
     classBody: TSESTree.ClassBody,
     methodName: string,

--- a/packages/eslint/src/rules/no-unused-props/props-usage-analyzer.ts
+++ b/packages/eslint/src/rules/no-unused-props/props-usage-analyzer.ts
@@ -8,6 +8,7 @@ import {
   PropsAliasVisitor,
   traverseNodes,
 } from "./visitor";
+import { INodeVisitor } from "./visitor/interface/node-visitor";
 
 export interface IPropsUsageAnalyzer {
   analyze(
@@ -69,48 +70,60 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
   }
 
   /**
-   * Tracks `this.<field> = props` bindings and scans the whole class for reads of that field.
-   * Handles both `Identifier` (`this.myProps`) and `PrivateIdentifier` (`this.#myProps`).
+   * Collects every `this.<field> = <paramName>` binding reachable inside `block` — including
+   * nested (`if (c) { this.a = props }`) and multiple assignments — then scans the whole class
+   * body for reads of each captured field. Both `Identifier` (`this.myProps`) and
+   * `PrivateIdentifier` (`this.#myProps`) targets are supported.
    */
   private checkUsageForInstanceVariable(
     classBody: TSESTree.ClassBody,
-    constructorBody: TSESTree.BlockStatement,
-    propsParamName: string,
+    block: TSESTree.BlockStatement,
+    paramName: string,
   ): void {
-    const binding = this.findPropsInstanceVariable(constructorBody, propsParamName);
-    if (!binding) return;
-
-    const visitor = new InstanceVariableUsageVisitor(
-      this.tracker,
-      binding.name,
-      binding.isPrivateField,
-    );
-    traverseNodes(classBody, visitor);
+    const bindings = findPropsInstanceVariableBindings(block, paramName);
+    for (const binding of bindings) {
+      const visitor = new InstanceVariableUsageVisitor(
+        this.tracker,
+        binding.name,
+        binding.isPrivateField,
+      );
+      traverseNodes(classBody, visitor);
+    }
   }
 
   /**
    * Follows `this.method(props)` chains from the constructor into method bodies (and further
-   * into any methods those bodies call). A visited set keyed by MethodDefinition node prevents
-   * infinite loops on recursive methods.
+   * into any methods those bodies call). `visited` is keyed by `${methodName}:${argIndex}` so
+   * the same method can still be analyzed for a different argument position, while recursion on
+   * the exact same method + arg-position is short-circuited.
+   *
+   * If a call cannot be tracked (target method missing, body-less, or the param at the props
+   * argument index is not a plain Identifier), the props object is treated as escaped and every
+   * property is marked used — otherwise `isTrackedFormForBareIdentifier` would have suppressed
+   * the escape mark without any per-property tracking taking its place.
    */
   private analyzeTransitiveMethodCalls(
     body: TSESTree.BlockStatement,
     classBody: TSESTree.ClassBody,
     paramName: string,
-    visited: Set<TSESTree.MethodDefinition>,
+    visited: Set<string>,
   ): void {
     const methodCalls = this.collectMethodCallsWithProps(body, paramName);
 
     for (const { methodName, propsArgIndices } of methodCalls) {
       const methodDef = this.findMethodDefinition(classBody, methodName);
-      if (!methodDef?.value.body) continue;
-      if (visited.has(methodDef)) continue;
-      visited.add(methodDef);
-
       for (const argIndex of propsArgIndices) {
-        const param = methodDef.value.params[argIndex];
-        if (param?.type !== AST_NODE_TYPES.Identifier) continue;
+        const visitedKey = `${methodName}:${argIndex}`;
+        if (visited.has(visitedKey)) continue;
+        visited.add(visitedKey);
+
+        const param = methodDef?.value.body ? methodDef.value.params[argIndex] : undefined;
+        if (!methodDef?.value.body || param?.type !== AST_NODE_TYPES.Identifier) {
+          this.tracker.markAllAsUsed();
+          continue;
+        }
         this.analyzeBlockForBinding(methodDef.value.body, param.name);
+        this.checkUsageForInstanceVariable(classBody, methodDef.value.body, param.name);
         this.analyzeTransitiveMethodCalls(methodDef.value.body, classBody, param.name, visited);
       }
     }
@@ -126,36 +139,9 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
   }
 
   /**
-   * Detects `this.<name> = props` or `this.#<name> = props` in the constructor's top-level
-   * statements. Returns the field's name and whether it is a `#`-prefixed private field.
+   * Resolves a class method by name, skipping overload signatures (body-less
+   * `TSEmptyBodyFunctionExpression` values) so the implementation is returned.
    */
-  private findPropsInstanceVariable(
-    body: TSESTree.BlockStatement,
-    propsParamName: string,
-  ): InstanceVarBinding | null {
-    for (const statement of body.body) {
-      if (statement.type !== AST_NODE_TYPES.ExpressionStatement) continue;
-      const expression = statement.expression;
-      if (expression.type !== AST_NODE_TYPES.AssignmentExpression) continue;
-      if (
-        expression.right.type !== AST_NODE_TYPES.Identifier ||
-        expression.right.name !== propsParamName
-      ) {
-        continue;
-      }
-      const left = expression.left;
-      if (left.type !== AST_NODE_TYPES.MemberExpression) continue;
-      if (left.object.type !== AST_NODE_TYPES.ThisExpression) continue;
-      if (left.property.type === AST_NODE_TYPES.Identifier) {
-        return { name: left.property.name, isPrivateField: false };
-      }
-      if (left.property.type === AST_NODE_TYPES.PrivateIdentifier) {
-        return { name: left.property.name, isPrivateField: true };
-      }
-    }
-    return null;
-  }
-
   private findMethodDefinition(
     classBody: TSESTree.ClassBody,
     methodName: string,
@@ -164,7 +150,8 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
       if (
         member.type === AST_NODE_TYPES.MethodDefinition &&
         member.key.type === AST_NODE_TYPES.Identifier &&
-        member.key.name === methodName
+        member.key.name === methodName &&
+        member.value.type !== AST_NODE_TYPES.TSEmptyBodyFunctionExpression
       ) {
         return member;
       }
@@ -172,3 +159,37 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
     return null;
   }
 }
+
+/**
+ * Traversal-based collector for `this.<name> = <paramName>` / `this.#<name> = <paramName>`
+ * bindings inside a block. Returns every match (nested or repeated), preserving discovery
+ * order and de-duplicating on (name, isPrivateField).
+ */
+const findPropsInstanceVariableBindings = (
+  block: TSESTree.BlockStatement,
+  paramName: string,
+): InstanceVarBinding[] => {
+  const bindings: InstanceVarBinding[] = [];
+  const seen = new Set<string>();
+  const visitor: INodeVisitor = {
+    visitAssignmentExpression: (node) => {
+      if (node.right.type !== AST_NODE_TYPES.Identifier || node.right.name !== paramName) return;
+      const left = node.left;
+      if (left.type !== AST_NODE_TYPES.MemberExpression) return;
+      if (left.object.type !== AST_NODE_TYPES.ThisExpression) return;
+      const isPrivateField = left.property.type === AST_NODE_TYPES.PrivateIdentifier;
+      if (
+        left.property.type !== AST_NODE_TYPES.Identifier &&
+        left.property.type !== AST_NODE_TYPES.PrivateIdentifier
+      ) {
+        return;
+      }
+      const key = `${isPrivateField ? "#" : ""}${left.property.name}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      bindings.push({ name: left.property.name, isPrivateField });
+    },
+  };
+  traverseNodes(block, visitor);
+  return bindings;
+};

--- a/packages/eslint/src/rules/no-unused-props/props-usage-tracker.ts
+++ b/packages/eslint/src/rules/no-unused-props/props-usage-tracker.ts
@@ -84,25 +84,20 @@ export class PropsUsageTracker implements IPropsUsageTracker {
     node: TSESTree.MemberExpression,
     propsParamName: string,
   ): void {
-    // NOTE: Check for props.propertyName or props?.propertyName pattern
-    if (
-      node.object.type === AST_NODE_TYPES.Identifier &&
-      node.object.name === propsParamName &&
-      node.property.type === AST_NODE_TYPES.Identifier
-    ) {
-      this.markAsUsed(node.property.name);
+    // NOTE: props.x / props?.x / props["x"] / props[<other>]
+    if (node.object.type === AST_NODE_TYPES.Identifier && node.object.name === propsParamName) {
+      this.markPropertyFromAccess(node);
       return;
     }
 
-    // NOTE: Check for this.props.propertyName or this.props?.propertyName pattern
+    // NOTE: this.props.x / this.props?.x / this.props["x"] (parameter-property style bindings)
     if (
       node.object.type === AST_NODE_TYPES.MemberExpression &&
       node.object.object.type === AST_NODE_TYPES.ThisExpression &&
       node.object.property.type === AST_NODE_TYPES.Identifier &&
-      node.object.property.name === propsParamName &&
-      node.property.type === AST_NODE_TYPES.Identifier
+      node.object.property.name === propsParamName
     ) {
-      this.markAsUsed(node.property.name);
+      this.markPropertyFromAccess(node);
       return;
     }
   }
@@ -111,7 +106,6 @@ export class PropsUsageTracker implements IPropsUsageTracker {
     node: TSESTree.VariableDeclarator,
     propsParamName: string,
   ): void {
-    // NOTE: Check for destructuring assignment: const { prop1, prop2 } = props
     if (
       node.id.type !== AST_NODE_TYPES.ObjectPattern ||
       node.init?.type !== AST_NODE_TYPES.Identifier ||
@@ -120,9 +114,13 @@ export class PropsUsageTracker implements IPropsUsageTracker {
       return;
     }
 
-    const names = findPropertyNames(node.id.properties);
-    for (const name of names) {
+    for (const name of findPropertyNames(node.id.properties)) {
       this.markAsUsed(name);
+    }
+    // NOTE: `const { a, ...rest } = props` — the rest binding captures the remaining
+    // properties opaquely, so treat them all as used
+    if (node.id.properties.some((p) => p.type === AST_NODE_TYPES.RestElement)) {
+      this.markAllAsUsed();
     }
   }
 
@@ -141,9 +139,28 @@ export class PropsUsageTracker implements IPropsUsageTracker {
     }
 
     this.markAsUsed(node.right.property.name);
+  }
 
-    // NOTE: this.props = props pattern doesn't mark all properties as used
-    // because we still need to check which properties are actually accessed later
+  /**
+   * Marks the property targeted by the given member expression's `property` node. Falls back to
+   * marking all properties when the access is computed with a non-string-literal key.
+   */
+  private markPropertyFromAccess(node: TSESTree.MemberExpression): void {
+    const property = node.property;
+    if (!node.computed && property.type === AST_NODE_TYPES.Identifier) {
+      this.markAsUsed(property.name);
+      return;
+    }
+    if (
+      node.computed &&
+      property.type === AST_NODE_TYPES.Literal &&
+      typeof property.value === "string"
+    ) {
+      this.markAsUsed(property.value);
+      return;
+    }
+    // NOTE: props[variable] / props[expr] — key is opaque, so all properties are treated as used
+    this.markAllAsUsed();
   }
 
   /**

--- a/packages/eslint/src/rules/no-unused-props/visitor/direct-props-usage-visitor.ts
+++ b/packages/eslint/src/rules/no-unused-props/visitor/direct-props-usage-visitor.ts
@@ -1,27 +1,22 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { TSESTree } from "@typescript-eslint/utils";
 
 import { IPropsUsageTracker } from "../props-usage-tracker";
 import { INodeVisitor } from "./interface/node-visitor";
+import { isTrackedFormForBareIdentifier } from "./is-tracked-form";
 
 /**
  * Visitor that tracks direct usage of the props parameter.
  *
- * This visitor detects various patterns where props is accessed directly:
- * - `props.bucketName` - Property access
- * - `const { bucketName } = props` - Destructuring assignment
- * - `this.bucketName = props.bucketName` - Assignment expression
- * - `console.log(props)` - Whole object usage (marks all properties as used)
+ * The per-property tracked forms are:
+ * - `props.x` / `props?.x` / `props["x"]`      (MemberExpression)
+ * - `const { x } = props`                       (VariableDeclarator, destructuring)
+ * - `const alias = props`                       (VariableDeclarator, alias — handled by PropsAliasVisitor)
+ * - `this.x = props` / `this.#x = props`        (AssignmentExpression — handled by analyzer)
+ * - `this.method(props)`                        (CallExpression — handled by analyzer)
  *
- * @example
- * ```typescript
- * constructor(scope: Construct, id: string, props: MyConstructProps) {
- *   super(scope, id);
- *   const name = props.bucketName;           // <- Detected by visitMemberExpression
- *   const { enableVersioning } = props;      // <- Detected by visitVariableDeclarator
- *   this.name = props.bucketName;            // <- Detected by visitAssignmentExpression
- *   console.log(props);                      // <- Detected by visitIdentifier (marks all)
- * }
- * ```
+ * Any other occurrence of a bare `props` identifier (`new Foo(x, id, props)`, `{ ...props }`,
+ * `"k" in props`, `return props`, etc.) is treated as a whole-object escape: all properties
+ * are marked as used, because we cannot statically know which will be accessed.
  */
 export class DirectPropsUsageVisitor implements INodeVisitor {
   constructor(
@@ -42,103 +37,8 @@ export class DirectPropsUsageVisitor implements INodeVisitor {
   }
 
   visitIdentifier(node: TSESTree.Identifier): void {
-    /**
-     * Handles cases where the props identifier is used as a whole value.
-     *
-     * This method detects when `props` (or the configured propsParamName) is used
-     * in contexts where all properties should be marked as used, because we cannot
-     * statically determine which properties will be accessed at runtime.
-     *
-     * Handled patterns:
-     *
-     * 1. **External function call** (`someFunction(props)` or `console.log(props)`):
-     *    - Marks ALL properties as used
-     *    - Excludes `this.method(props)` which is handled by analyzePrivateMethodsCalledFromConstructor
-     *
-     *    AST structure:
-     *      CallExpression
-     *      ├── callee: Identifier (someFunction) or MemberExpression (console.log)
-     *      └── arguments: [Identifier (name: "props")]
-     *
-     * 2. **Return statement** (`return props`):
-     *    - Marks ALL properties as used
-     *
-     *    AST structure:
-     *      ReturnStatement
-     *      └── argument: Identifier (name: "props")
-     *
-     * 3. **Array element** (`[props]` or `[a, props, b]`):
-     *    - Marks ALL properties as used
-     *
-     *    AST structure:
-     *      ArrayExpression
-     *      └── elements: [..., Identifier (name: "props"), ...]
-     *
-     * 4. **Object property value** (`{ key: props }`):
-     *    - Marks ALL properties as used
-     *
-     *    AST structure:
-     *      Property
-     *      ├── key: Identifier (name: "key")
-     *      └── value: Identifier (name: "props")
-     *
-     * The following cases are intentionally excluded (handled elsewhere):
-     * - `props.xxx` (MemberExpression) - handled by visitMemberExpression
-     * - `const { xxx } = props` (VariableDeclarator with ObjectPattern) - handled by visitVariableDeclarator
-     * - `this.xxx = props.xxx` (AssignmentExpression) - handled by visitAssignmentExpression
-     * - `this.method(props)` (CallExpression with ThisExpression callee) - handled by analyzePrivateMethodsCalledFromConstructor
-     * - `const a = props` (alias registration) - handled by PropsAliasVisitor
-     */
-
-    // NOTE: Check if props object is used as a whole (e.g., console.log(props))
     if (node.name !== this.propsParamName) return;
-
-    const parent = node.parent;
-    if (!parent) return;
-
-    switch (parent.type) {
-      // NOTE: Pattern 1: External function call
-      case AST_NODE_TYPES.CallExpression: {
-        if (!parent.arguments.includes(node)) return;
-        if (
-          parent.callee.type === AST_NODE_TYPES.MemberExpression &&
-          parent.callee.object.type === AST_NODE_TYPES.ThisExpression
-        ) {
-          return;
-        }
-        this.tracker.markAllAsUsed();
-        return;
-      }
-
-      // NOTE: Pattern 2: Return statement
-      case AST_NODE_TYPES.ReturnStatement: {
-        // NOTE: return props - props as a whole
-        if (parent.argument === node) {
-          this.tracker.markAllAsUsed();
-        }
-        return;
-      }
-
-      // NOTE: Pattern 3: Array element
-      case AST_NODE_TYPES.ArrayExpression: {
-        // NOTE: [props] - props as a whole
-        if (parent.elements.includes(node)) {
-          this.tracker.markAllAsUsed();
-        }
-        return;
-      }
-
-      // NOTE: Pattern 4: Object property value
-      case AST_NODE_TYPES.Property: {
-        // NOTE: { key: props } - props as a whole
-        if (parent.value === node) {
-          this.tracker.markAllAsUsed();
-        }
-        return;
-      }
-      default: {
-        return;
-      }
-    }
+    if (isTrackedFormForBareIdentifier(node)) return;
+    this.tracker.markAllAsUsed();
   }
 }

--- a/packages/eslint/src/rules/no-unused-props/visitor/instance-variable-usage-visitor.ts
+++ b/packages/eslint/src/rules/no-unused-props/visitor/instance-variable-usage-visitor.ts
@@ -4,107 +4,66 @@ import { IPropsUsageTracker } from "../props-usage-tracker";
 import { INodeVisitor } from "./interface/node-visitor";
 
 /**
- * Visitor that tracks props usage through instance variables.
+ * Tracks props usage through an instance field (`this.myProps` or `this.#myProps`) that
+ * mirrors the props parameter.
  *
- * When props is assigned to an instance variable (e.g., `this.myProps = props`),
- * this visitor tracks property access on that instance variable throughout the class.
- *
- * Handles two patterns:
- * 1. Property access: `this.myProps.bucketName` - marks specific property as used
- * 2. Whole object usage: `console.log(this.myProps)` - marks all properties as used
- *
- * @example
- * ```typescript
- * class MyConstruct extends Construct {
- *   private myProps: MyConstructProps;
- *
- *   constructor(scope: Construct, id: string, props: MyConstructProps) {
- *     super(scope, id);
- *     this.myProps = props;
- *   }
- *
- *   someMethod() {
- *     console.log(this.myProps.bucketName);  // <- 'bucketName' is marked as used
- *   }
- * }
- * ```
+ * Handles:
+ * - `this.myProps.bucketName` / `this.myProps?.bucketName` / `this.myProps["bucketName"]` —
+ *   marks the referenced property
+ * - `this.myProps` used as a whole value — marks all properties (assignment LHS excluded)
  */
 export class InstanceVariableUsageVisitor implements INodeVisitor {
   constructor(
     private readonly tracker: IPropsUsageTracker,
     private readonly instanceVarName: string,
+    private readonly isPrivateField: boolean = false,
   ) {}
 
   visitMemberExpression(node: TSESTree.MemberExpression): void {
-    // ===========================================================================
-    // Pattern 1: Property access - this.instanceVarName.propertyName
-    // ===========================================================================
-    // Matches code like: `console.log(this.myProps.bucketName)` or `return this.myProps.enableVersioning`
-    //
-    // AST structure:
-    //   MemberExpression (node)
-    //   ├── object: MemberExpression (this.myProps)
-    //   │   ├── object: ThisExpression
-    //   │   └── property: Identifier (name: "myProps" === instanceVarName)
-    //   └── property: Identifier (name: "bucketName" - the property being accessed)
-    //
-    // When this pattern matches, we mark the accessed property (e.g., "bucketName") as used.
+    // NOTE: this.instanceVarName.<prop> (nested MemberExpression)
     if (
-      node.type === AST_NODE_TYPES.MemberExpression &&
       node.object.type === AST_NODE_TYPES.MemberExpression &&
-      node.object.object.type === AST_NODE_TYPES.ThisExpression &&
-      node.object.property.type === AST_NODE_TYPES.Identifier &&
-      node.object.property.name === this.instanceVarName &&
-      node.property.type === AST_NODE_TYPES.Identifier
+      this.isMatchingThisMember(node.object)
     ) {
-      this.tracker.markAsUsed(node.property.name);
+      this.markProperty(node);
       return;
     }
 
-    // ===========================================================================
-    // Pattern 2: Whole object usage - this.instanceVarName used as a value
-    // ===========================================================================
-    // Matches code like: `console.log(this.myProps)` or `return this.myProps`
-    //
-    // AST structure:
-    //   MemberExpression (node)
-    //   ├── object: ThisExpression
-    //   └── property: Identifier (name: "myProps" === instanceVarName)
-    //
-    // However, we need to exclude certain cases where `this.myProps` appears
-    // but isn't actually being "used as a value":
-    //
-    // Exclusion A: Property access (handled by Pattern 1 above)
-    //   Code: `this.myProps.bucketName`
-    //   The `this.myProps` part has parent MemberExpression where it's the object
-    //
-    // Exclusion B: Assignment left-hand side
-    //   Code: `this.myProps = props`
-    //   The `this.myProps` is being assigned to, not used as a value
-    if (
-      node.type === AST_NODE_TYPES.MemberExpression &&
-      node.object.type === AST_NODE_TYPES.ThisExpression &&
-      node.property.type === AST_NODE_TYPES.Identifier &&
-      node.property.name === this.instanceVarName
-    ) {
+    if (this.isMatchingThisMember(node)) {
+      // NOTE: `this.myProps.<prop>` is handled above via the parent MemberExpression
       const parent = node.parent;
-
-      // NOTE: Exclusion A - Skip if this is part of a property access (this.myProps.xxx)
-      // The parent MemberExpression's object being this node means we're accessing a property
-      if (parent?.type === AST_NODE_TYPES.MemberExpression && parent.object === node) {
-        return;
-      }
-
-      // NOTE: Exclusion B - Skip if this is the left side of an assignment (this.myProps = ...)
-      if (parent?.type === AST_NODE_TYPES.AssignmentExpression && parent.left === node) {
-        return;
-      }
-
-      // NOTE: If we reach here, `this.myProps` is used as a whole value
-      // Examples: console.log(this.myProps), return this.myProps, [this.myProps], etc.
-      // Since we can't know which properties will be accessed at runtime, mark all as used
+      if (parent?.type === AST_NODE_TYPES.MemberExpression && parent.object === node) return;
+      // NOTE: `this.myProps = ...` is an assignment, not a read
+      if (parent?.type === AST_NODE_TYPES.AssignmentExpression && parent.left === node) return;
       this.tracker.markAllAsUsed();
+    }
+  }
+
+  private isMatchingThisMember(node: TSESTree.MemberExpression): boolean {
+    if (node.object.type !== AST_NODE_TYPES.ThisExpression) return false;
+    const property = node.property;
+    if (this.isPrivateField) {
+      return (
+        property.type === AST_NODE_TYPES.PrivateIdentifier && property.name === this.instanceVarName
+      );
+    }
+    return property.type === AST_NODE_TYPES.Identifier && property.name === this.instanceVarName;
+  }
+
+  private markProperty(node: TSESTree.MemberExpression): void {
+    const property = node.property;
+    if (!node.computed && property.type === AST_NODE_TYPES.Identifier) {
+      this.tracker.markAsUsed(property.name);
       return;
     }
+    if (
+      node.computed &&
+      property.type === AST_NODE_TYPES.Literal &&
+      typeof property.value === "string"
+    ) {
+      this.tracker.markAsUsed(property.value);
+      return;
+    }
+    this.tracker.markAllAsUsed();
   }
 }

--- a/packages/eslint/src/rules/no-unused-props/visitor/is-tracked-form.ts
+++ b/packages/eslint/src/rules/no-unused-props/visitor/is-tracked-form.ts
@@ -38,6 +38,34 @@ export const isTrackedFormForBareIdentifier = (node: TSESTree.Identifier): boole
   }
 };
 
+/**
+ * Narrower tracked-form check for alias identifiers (variables bound via `const a = props`).
+ *
+ * Aliases are only tracked when they appear as a member-access object (`a.x`) or as the RHS of
+ * a destructuring declaration (`const { x } = a`). Every other position — including plain
+ * `const b = a`, `this.x = a`, `this.m(a)` — is treated as a whole-object escape because there
+ * is no alias-of-alias, instance-variable, or method-call tracking for aliased references.
+ */
+export const isTrackedFormForAliasIdentifier = (node: TSESTree.Identifier): boolean => {
+  const parent = node.parent;
+  if (!parent) return true;
+
+  if (isNonReferencePosition(node, parent)) return true;
+
+  switch (parent.type) {
+    case AST_NODE_TYPES.MemberExpression: {
+      return parent.object === node;
+    }
+    case AST_NODE_TYPES.VariableDeclarator: {
+      // NOTE: destructuring `const { x } = alias` is tracked; plain `const b = alias` is not.
+      return parent.init === node && parent.id.type === AST_NODE_TYPES.ObjectPattern;
+    }
+    default: {
+      return false;
+    }
+  }
+};
+
 const isNonReferencePosition = (node: TSESTree.Identifier, parent: TSESTree.Node): boolean => {
   switch (parent.type) {
     case AST_NODE_TYPES.MemberExpression: {
@@ -71,8 +99,12 @@ const isThisMemberLeft = (left: TSESTree.Node): boolean => {
 
 const isThisMethodCall = (call: TSESTree.CallExpression): boolean => {
   const callee = call.callee;
+  // NOTE: computed calls (`this["m"](props)`) are not collected by MethodCallCollectorVisitor,
+  // so they must fall through to the whole-object escape path.
   return (
     callee.type === AST_NODE_TYPES.MemberExpression &&
-    callee.object.type === AST_NODE_TYPES.ThisExpression
+    !callee.computed &&
+    callee.object.type === AST_NODE_TYPES.ThisExpression &&
+    callee.property.type === AST_NODE_TYPES.Identifier
   );
 };

--- a/packages/eslint/src/rules/no-unused-props/visitor/is-tracked-form.ts
+++ b/packages/eslint/src/rules/no-unused-props/visitor/is-tracked-form.ts
@@ -1,0 +1,78 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+
+/**
+ * Returns true when the given identifier does NOT need to be marked as a whole-object escape,
+ * either because it is not a value reference at all (e.g. a property key like `this.props`)
+ * or because it appears in a form whose per-property usage is tracked precisely elsewhere in
+ * the analyzer.
+ *
+ * Any other position is a whole-object escape and should mark all properties as used.
+ */
+export const isTrackedFormForBareIdentifier = (node: TSESTree.Identifier): boolean => {
+  const parent = node.parent;
+  if (!parent) return true;
+
+  // NOTE: non-reference positions — the identifier is a name label, not a variable read
+  if (isNonReferencePosition(node, parent)) return true;
+
+  switch (parent.type) {
+    // NOTE: `props.x` / `props?.x` / `props["x"]` — per-property tracked
+    case AST_NODE_TYPES.MemberExpression: {
+      return parent.object === node;
+    }
+    // NOTE: `const x = props` / `const { x } = props` — alias/destructuring tracked
+    case AST_NODE_TYPES.VariableDeclarator: {
+      return parent.init === node;
+    }
+    // NOTE: `this.x = props` / `this.#x = props` — instance-variable tracked
+    case AST_NODE_TYPES.AssignmentExpression: {
+      return parent.right === node && isThisMemberLeft(parent.left);
+    }
+    // NOTE: `this.method(props)` — transitive method-body tracked
+    case AST_NODE_TYPES.CallExpression: {
+      return isThisMethodCall(parent) && parent.arguments.includes(node);
+    }
+    default: {
+      return false;
+    }
+  }
+};
+
+const isNonReferencePosition = (node: TSESTree.Identifier, parent: TSESTree.Node): boolean => {
+  switch (parent.type) {
+    case AST_NODE_TYPES.MemberExpression: {
+      // NOTE: `x.props` — `props` is a property name, not a variable read
+      return !parent.computed && parent.property === node;
+    }
+    case AST_NODE_TYPES.Property: {
+      // NOTE: `{ props: value }` — non-shorthand key is a name label
+      return !parent.computed && !parent.shorthand && parent.key === node;
+    }
+    case AST_NODE_TYPES.MethodDefinition:
+    case AST_NODE_TYPES.PropertyDefinition:
+    case AST_NODE_TYPES.TSPropertySignature:
+    case AST_NODE_TYPES.TSMethodSignature: {
+      return !parent.computed && parent.key === node;
+    }
+    default: {
+      return false;
+    }
+  }
+};
+
+const isThisMemberLeft = (left: TSESTree.Node): boolean => {
+  if (left.type !== AST_NODE_TYPES.MemberExpression) return false;
+  if (left.object.type !== AST_NODE_TYPES.ThisExpression) return false;
+  return (
+    left.property.type === AST_NODE_TYPES.Identifier ||
+    left.property.type === AST_NODE_TYPES.PrivateIdentifier
+  );
+};
+
+const isThisMethodCall = (call: TSESTree.CallExpression): boolean => {
+  const callee = call.callee;
+  return (
+    callee.type === AST_NODE_TYPES.MemberExpression &&
+    callee.object.type === AST_NODE_TYPES.ThisExpression
+  );
+};

--- a/packages/eslint/src/rules/no-unused-props/visitor/props-alias-visitor.ts
+++ b/packages/eslint/src/rules/no-unused-props/visitor/props-alias-visitor.ts
@@ -2,7 +2,7 @@ import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 
 import { IPropsUsageTracker } from "../props-usage-tracker";
 import { INodeVisitor } from "./interface/node-visitor";
-import { isTrackedFormForBareIdentifier } from "./is-tracked-form";
+import { isTrackedFormForAliasIdentifier } from "./is-tracked-form";
 
 /**
  * Tracks props usage through variable aliases.
@@ -46,7 +46,7 @@ export class PropsAliasVisitor implements INodeVisitor {
       return;
     }
     if (!this.aliases.has(node.name)) return;
-    if (isTrackedFormForBareIdentifier(node)) return;
+    if (isTrackedFormForAliasIdentifier(node)) return;
     this.tracker.markAllAsUsed();
   }
 

--- a/packages/eslint/src/rules/no-unused-props/visitor/props-alias-visitor.ts
+++ b/packages/eslint/src/rules/no-unused-props/visitor/props-alias-visitor.ts
@@ -2,21 +2,19 @@ import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 
 import { IPropsUsageTracker } from "../props-usage-tracker";
 import { INodeVisitor } from "./interface/node-visitor";
+import { isTrackedFormForBareIdentifier } from "./is-tracked-form";
 
 /**
- * Visitor that tracks props usage through variable aliases.
+ * Tracks props usage through variable aliases.
  *
- * When props is assigned to another variable (alias), this visitor:
- * 1. Registers the alias when `const myProps = props` is detected
- * 2. Tracks property access on the alias like `myProps.bucketName`
+ * `const alias = props` registers `alias` and the same tracked-form / whole-escape rules used
+ * for `props` itself are then applied to occurrences of `alias`.
  *
  * @example
  * ```typescript
- * constructor(scope: Construct, id: string, props: MyConstructProps) {
- *   super(scope, id);
- *   const myProps = props;              // <- Alias 'myProps' is registered
- *   console.log(myProps.bucketName);    // <- 'bucketName' is marked as used
- * }
+ * const alias = props;
+ * console.log(alias.bucketName);           // per-property mark
+ * new Bucket(this, "B", alias);            // whole-escape → mark all
  * ```
  */
 export class PropsAliasVisitor implements INodeVisitor {
@@ -29,48 +27,33 @@ export class PropsAliasVisitor implements INodeVisitor {
 
   visitMemberExpression(node: TSESTree.MemberExpression): void {
     this.tracker.markAsUsedForMemberExpression(node, this.propsParamName);
-    /**
-     * NOTE: Check if the object is an alias of props
-     * ```ts
-     * const myProps = props;
-     * console.log(myProps.bucketName); // <- detect this access
-     * ```
-     */
-    if (
-      node.object.type === AST_NODE_TYPES.Identifier &&
-      this.aliases.has(node.object.name) &&
-      node.property.type === AST_NODE_TYPES.Identifier
-    ) {
-      this.tracker.markAsUsed(node.property.name);
+    if (node.object.type === AST_NODE_TYPES.Identifier && this.aliases.has(node.object.name)) {
+      this.tracker.markAsUsedForMemberExpression(node, node.object.name);
+    }
+  }
+
+  visitVariableDeclarator(node: TSESTree.VariableDeclarator): void {
+    // NOTE: `const { x, ...rest } = alias` — mirror the direct destructuring behavior for aliases
+    if (node.init?.type !== AST_NODE_TYPES.Identifier) return;
+    if (this.aliases.has(node.init.name)) {
+      this.tracker.markAsUsedForVariableDeclarator(node, node.init.name);
     }
   }
 
   visitIdentifier(node: TSESTree.Identifier): void {
-    /**
-     * Handles alias registration for props.
-     *
-     * This method detects when props is assigned to a simple variable,
-     * which creates an alias that should be tracked for property access.
-     *
-     * Handled pattern:
-     *
-     * **Variable assignment** (`const myProps = props`):
-     *    - Registers 'myProps' as an alias of props
-     *    - Later access like `myProps.bucketName` will be detected by visitMemberExpression
-     *
-     *    AST structure:
-     *      VariableDeclarator
-     *      ├── id: Identifier (name: "myProps" - the alias to register)
-     *      └── init: Identifier (name: "props")
-     */
-    if (node.name !== this.propsParamName) return;
+    if (node.name === this.propsParamName) {
+      this.registerAliasIfDeclaration(node);
+      return;
+    }
+    if (!this.aliases.has(node.name)) return;
+    if (isTrackedFormForBareIdentifier(node)) return;
+    this.tracker.markAllAsUsed();
+  }
 
+  private registerAliasIfDeclaration(node: TSESTree.Identifier): void {
     const parent = node.parent;
-    if (!parent) return;
-
-    // NOTE: const myProps = props - track 'myProps' as an alias of props
     if (
-      parent.type === AST_NODE_TYPES.VariableDeclarator &&
+      parent?.type === AST_NODE_TYPES.VariableDeclarator &&
       parent.init === node &&
       parent.id.type === AST_NODE_TYPES.Identifier
     ) {

--- a/packages/oxlint/src/__tests__/no-unused-props.test.ts
+++ b/packages/oxlint/src/__tests__/no-unused-props.test.ts
@@ -750,6 +750,144 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       }
       `,
     },
+    {
+      name: "Props is passed to an inherited method (unresolved) — treated as whole usage",
+      code: `
+      class Construct {
+        protected inheritedHelper(_props: unknown): void {}
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.inheritedHelper(props);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is passed via computed this-call — treated as whole usage",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this["setup"](props);
+        }
+        private setup(p: MyConstructProps) {
+          console.log(p.bucketName);
+        }
+      }
+      `,
+    },
+    {
+      name: "Alias is passed to a this-method — treated as whole usage of the alias",
+      code: `
+      class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: any) { super(scope, id); }
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          const bucketProps = props;
+          this.store(bucketProps);
+        }
+        private store(p: unknown) {
+          console.log(p);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is assigned to instance field inside a conditional and read elsewhere",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        #props?: MyConstructProps;
+        constructor(scope: Construct, id: string, props: MyConstructProps, condition: boolean) {
+          super(scope, id);
+          if (condition) {
+            this.#props = props;
+          }
+        }
+        log() {
+          console.log(this.#props?.bucketName, this.#props?.enableVersioning);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is assigned to multiple instance fields and every field is read",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        private a?: MyConstructProps;
+        private b?: MyConstructProps;
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.a = props;
+          this.b = props;
+        }
+        log() {
+          console.log(this.a?.bucketName);
+          console.log(this.b?.enableVersioning);
+        }
+      }
+      `,
+    },
+    {
+      name: "Same method is called with props at two different arg positions",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.m(props, {} as MyConstructProps);
+          this.m({} as MyConstructProps, props);
+        }
+        private m(first: MyConstructProps, second: MyConstructProps) {
+          console.log(first.bucketName);
+          console.log(second.enableVersioning);
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {
@@ -1142,6 +1280,29 @@ ruleTester.run("no-unused-props", noUnusedProps, {
         }
         private createBucket(p: MyConstructProps) {
           new Bucket(this, "B", { bucketName: p.bucketName, versioned: p.enableVersioning });
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "Instance-variable binding still reports properties that no method reads",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        unusedProp: string;
+      }
+
+      export class MyConstruct extends Construct {
+        private myProps: MyConstructProps;
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.myProps = props;
+        }
+        log() {
+          console.log(this.myProps.bucketName);
         }
       }
       `,

--- a/packages/oxlint/src/__tests__/no-unused-props.test.ts
+++ b/packages/oxlint/src/__tests__/no-unused-props.test.ts
@@ -560,6 +560,196 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       }
       `,
     },
+    {
+      name: "Props is passed as whole to NewExpression argument",
+      code: `
+      class Construct {}
+      class Queue extends Construct {
+        constructor(scope: Construct, id: string, props: any) { super(scope, id); }
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          new Queue(this, "Queue", props);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is spread into a NewExpression argument object",
+      code: `
+      class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: any) { super(scope, id); }
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          new Bucket(this, "Dest", { ...props, extra: true });
+        }
+      }
+      `,
+    },
+    {
+      name: "Props alias is passed as a whole to a NewExpression argument",
+      code: `
+      class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: any) { super(scope, id); }
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          const bucketProps = props;
+          new Bucket(this, "Dest", bucketProps);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is queried via 'in' operator",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        encryption: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          if ("encryption" in props) {
+            console.log("encrypted");
+          }
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is destructured with a rest element",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        logPrefix: string;
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          const { logPrefix, ...bucketProps } = props;
+          console.log(logPrefix, bucketProps);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is accessed via string literal computed key",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          console.log(props["bucketName"], props["enableVersioning"]);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is accessed via a variable computed key (treated as whole usage)",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          const key: keyof MyConstructProps = "bucketName";
+          console.log(props[key]);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is assigned to a private field via # and its properties are used",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      class MyConstruct extends Construct {
+        #props: MyConstructProps;
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.#props = props;
+        }
+        log() {
+          console.log(this.#props.bucketName, this.#props.enableVersioning);
+        }
+      }
+      `,
+    },
+    {
+      name: "Props is passed transitively through two private methods",
+      code: `
+      class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: any) { super(scope, id); }
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.setup(props);
+        }
+        private setup(p: MyConstructProps) {
+          this.createBucket(p);
+        }
+        private createBucket(p: MyConstructProps) {
+          new Bucket(this, "B", { bucketName: p.bucketName, versioned: p.enableVersioning });
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {
@@ -904,6 +1094,54 @@ ruleTester.run("no-unused-props", noUnusedProps, {
         constructor(scope: Construct, id: string, props: MyConstructProps = {} as MyConstructProps) {
           super(scope, id);
           console.log(props.bucketName);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "String literal computed access reports only untouched properties",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          console.log(props["bucketName"]);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "enableVersioning" } }],
+    },
+    {
+      name: "Transitive method chain still reports properties never referenced",
+      code: `
+      class Construct {}
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string, props: any) { super(scope, id); }
+      }
+
+      interface MyConstructProps {
+        bucketName: string;
+        enableVersioning: boolean;
+        unusedProp: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          this.setup(props);
+        }
+        private setup(p: MyConstructProps) {
+          this.createBucket(p);
+        }
+        private createBucket(p: MyConstructProps) {
+          new Bucket(this, "B", { bucketName: p.bucketName, versioned: p.enableVersioning });
         }
       }
       `,

--- a/packages/oxlint/src/rules/no-unused-props/props-usage-analyzer.ts
+++ b/packages/oxlint/src/rules/no-unused-props/props-usage-analyzer.ts
@@ -10,6 +10,7 @@ import {
   PropsAliasVisitor,
   traverseNodes,
 } from "./visitor";
+import { INodeVisitor } from "./visitor/interface/node-visitor";
 
 export interface IPropsUsageAnalyzer {
   analyze(
@@ -72,48 +73,60 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
   }
 
   /**
-   * Tracks `this.<field> = props` bindings and scans the whole class for reads of that field.
-   * Handles both `Identifier` (`this.myProps`) and `PrivateIdentifier` (`this.#myProps`).
+   * Collects every `this.<field> = <paramName>` binding reachable inside `block` — including
+   * nested (`if (c) { this.a = props }`) and multiple assignments — then scans the whole class
+   * body for reads of each captured field. Both `Identifier` (`this.myProps`) and
+   * `PrivateIdentifier` (`this.#myProps`) targets are supported.
    */
   private checkUsageForInstanceVariable(
     classBody: ESTree.ClassBody,
-    constructorBody: ESTree.BlockStatement,
-    propsParamName: string,
+    block: ESTree.BlockStatement,
+    paramName: string,
   ): void {
-    const binding = this.findPropsInstanceVariable(constructorBody, propsParamName);
-    if (!binding) return;
-
-    const visitor = new InstanceVariableUsageVisitor(
-      this.tracker,
-      binding.name,
-      binding.isPrivateField,
-    );
-    traverseNodes(classBody, visitor);
+    const bindings = findPropsInstanceVariableBindings(block, paramName);
+    for (const binding of bindings) {
+      const visitor = new InstanceVariableUsageVisitor(
+        this.tracker,
+        binding.name,
+        binding.isPrivateField,
+      );
+      traverseNodes(classBody, visitor);
+    }
   }
 
   /**
    * Follows `this.method(props)` chains from the constructor into method bodies (and further
-   * into any methods those bodies call). A visited set keyed by MethodDefinition node prevents
-   * infinite loops on recursive methods.
+   * into any methods those bodies call). `visited` is keyed by `${methodName}:${argIndex}` so
+   * the same method can still be analyzed for a different argument position, while recursion on
+   * the exact same method + arg-position is short-circuited.
+   *
+   * If a call cannot be tracked (target method missing, body-less, or the param at the props
+   * argument index is not a plain Identifier), the props object is treated as escaped and every
+   * property is marked used — otherwise `isTrackedFormForBareIdentifier` would have suppressed
+   * the escape mark without any per-property tracking taking its place.
    */
   private analyzeTransitiveMethodCalls(
     body: ESTree.BlockStatement,
     classBody: ESTree.ClassBody,
     paramName: string,
-    visited: Set<ESTree.MethodDefinition>,
+    visited: Set<string>,
   ): void {
     const methodCalls = this.collectMethodCallsWithProps(body, paramName);
 
     for (const { methodName, propsArgIndices } of methodCalls) {
       const methodDef = this.findMethodDefinition(classBody, methodName);
-      if (!methodDef?.value.body) continue;
-      if (visited.has(methodDef)) continue;
-      visited.add(methodDef);
-
       for (const argIndex of propsArgIndices) {
-        const param = methodDef.value.params[argIndex];
-        if (param?.type !== AST_NODE_TYPES.Identifier) continue;
+        const visitedKey = `${methodName}:${argIndex}`;
+        if (visited.has(visitedKey)) continue;
+        visited.add(visitedKey);
+
+        const param = methodDef?.value.body ? methodDef.value.params[argIndex] : undefined;
+        if (!methodDef?.value.body || param?.type !== AST_NODE_TYPES.Identifier) {
+          this.tracker.markAllAsUsed();
+          continue;
+        }
         this.analyzeBlockForBinding(methodDef.value.body, param.name);
+        this.checkUsageForInstanceVariable(classBody, methodDef.value.body, param.name);
         this.analyzeTransitiveMethodCalls(methodDef.value.body, classBody, param.name, visited);
       }
     }
@@ -129,36 +142,9 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
   }
 
   /**
-   * Detects `this.<name> = props` or `this.#<name> = props` in the constructor's top-level
-   * statements. Returns the field's name and whether it is a `#`-prefixed private field.
+   * Resolves a class method by name, skipping overload signatures (body-less
+   * `TSEmptyBodyFunctionExpression` values) so the implementation is returned.
    */
-  private findPropsInstanceVariable(
-    body: ESTree.BlockStatement,
-    propsParamName: string,
-  ): InstanceVarBinding | null {
-    for (const statement of body.body) {
-      if (statement.type !== AST_NODE_TYPES.ExpressionStatement) continue;
-      const expression = statement.expression;
-      if (expression.type !== AST_NODE_TYPES.AssignmentExpression) continue;
-      if (
-        expression.right.type !== AST_NODE_TYPES.Identifier ||
-        expression.right.name !== propsParamName
-      ) {
-        continue;
-      }
-      const left = expression.left;
-      if (left.type !== AST_NODE_TYPES.MemberExpression) continue;
-      if (left.object.type !== AST_NODE_TYPES.ThisExpression) continue;
-      if (left.property.type === AST_NODE_TYPES.Identifier) {
-        return { name: left.property.name, isPrivateField: false };
-      }
-      if (left.property.type === AST_NODE_TYPES.PrivateIdentifier) {
-        return { name: left.property.name, isPrivateField: true };
-      }
-    }
-    return null;
-  }
-
   private findMethodDefinition(
     classBody: ESTree.ClassBody,
     methodName: string,
@@ -167,7 +153,8 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
       if (
         member.type === AST_NODE_TYPES.MethodDefinition &&
         member.key.type === AST_NODE_TYPES.Identifier &&
-        member.key.name === methodName
+        member.key.name === methodName &&
+        member.value.type !== AST_NODE_TYPES.TSEmptyBodyFunctionExpression
       ) {
         return member;
       }
@@ -175,3 +162,37 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
     return null;
   }
 }
+
+/**
+ * Traversal-based collector for `this.<name> = <paramName>` / `this.#<name> = <paramName>`
+ * bindings inside a block. Returns every match (nested or repeated), preserving discovery
+ * order and de-duplicating on (name, isPrivateField).
+ */
+const findPropsInstanceVariableBindings = (
+  block: ESTree.BlockStatement,
+  paramName: string,
+): InstanceVarBinding[] => {
+  const bindings: InstanceVarBinding[] = [];
+  const seen = new Set<string>();
+  const visitor: INodeVisitor = {
+    visitAssignmentExpression: (node) => {
+      if (node.right.type !== AST_NODE_TYPES.Identifier || node.right.name !== paramName) return;
+      const left = node.left;
+      if (left.type !== AST_NODE_TYPES.MemberExpression) return;
+      if (left.object.type !== AST_NODE_TYPES.ThisExpression) return;
+      const isPrivateField = left.property.type === AST_NODE_TYPES.PrivateIdentifier;
+      if (
+        left.property.type !== AST_NODE_TYPES.Identifier &&
+        left.property.type !== AST_NODE_TYPES.PrivateIdentifier
+      ) {
+        return;
+      }
+      const key = `${isPrivateField ? "#" : ""}${left.property.name}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      bindings.push({ name: left.property.name, isPrivateField });
+    },
+  };
+  traverseNodes(block, visitor);
+  return bindings;
+};

--- a/packages/oxlint/src/rules/no-unused-props/props-usage-analyzer.ts
+++ b/packages/oxlint/src/rules/no-unused-props/props-usage-analyzer.ts
@@ -28,6 +28,11 @@ export interface AnalyzeOptions {
   treatAsInstanceVariable?: boolean;
 }
 
+type InstanceVarBinding = {
+  name: string;
+  isPrivateField: boolean;
+};
+
 export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
   private readonly tracker: IPropsUsageTracker;
 
@@ -45,183 +50,75 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
     if (!constructorBody) return;
     if (!classNode || classNode.type !== AST_NODE_TYPES.ClassBody) return;
 
-    this.checkUsageForDirectAccess(constructorBody, propsParamName);
-    this.checkUsageForAliasAccess(constructorBody, propsParamName);
-    this.checkUsageForInstanceVariable(classNode, constructor, propsParamName);
-    this.checkUsageForPrivateMethodsCalledFromConstructor(
-      constructorBody,
-      classNode,
-      propsParamName,
-    );
+    this.analyzeBlockForBinding(constructorBody, propsParamName);
+    this.checkUsageForInstanceVariable(classNode, constructorBody, propsParamName);
+    this.analyzeTransitiveMethodCalls(constructorBody, classNode, propsParamName, new Set());
     if (options.treatAsInstanceVariable) {
-      this.checkUsageForBoundInstanceVariable(classNode, propsParamName);
+      const visitor = new InstanceVariableUsageVisitor(this.tracker, propsParamName);
+      traverseNodes(classNode, visitor);
     }
   }
 
   /**
-   * Tracks usage through `this.<name>` for parameter-property-declared props, where
-   * TypeScript implicitly assigns the parameter to an instance field of the same name.
+   * Runs the direct-usage and alias visitors over a block (constructor body or a method body
+   * reached transitively via `this.method(props)`).
    */
-  private checkUsageForBoundInstanceVariable(classBody: ESTree.ClassBody, name: string): void {
-    const visitor = new InstanceVariableUsageVisitor(this.tracker, name);
+  private analyzeBlockForBinding(block: ESTree.BlockStatement, paramName: string): void {
+    const directVisitor = new DirectPropsUsageVisitor(this.tracker, paramName);
+    traverseNodes(block, directVisitor);
+
+    const aliasVisitor = new PropsAliasVisitor(this.tracker, paramName);
+    traverseNodes(block, aliasVisitor);
+  }
+
+  /**
+   * Tracks `this.<field> = props` bindings and scans the whole class for reads of that field.
+   * Handles both `Identifier` (`this.myProps`) and `PrivateIdentifier` (`this.#myProps`).
+   */
+  private checkUsageForInstanceVariable(
+    classBody: ESTree.ClassBody,
+    constructorBody: ESTree.BlockStatement,
+    propsParamName: string,
+  ): void {
+    const binding = this.findPropsInstanceVariable(constructorBody, propsParamName);
+    if (!binding) return;
+
+    const visitor = new InstanceVariableUsageVisitor(
+      this.tracker,
+      binding.name,
+      binding.isPrivateField,
+    );
     traverseNodes(classBody, visitor);
   }
 
   /**
-   * Analyzes direct access to props within the constructor body.
-   *
-   * @example
-   * ```typescript
-   * constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *   super(scope, id);
-   *   console.log(props.bucketName);  // <- Direct access tracked here
-   * }
-   * ```
-   *
-   * @param constructorBody - The constructor's BlockStatement to analyze
-   * @param propsParamName - The name of the props parameter (e.g., "props")
+   * Follows `this.method(props)` chains from the constructor into method bodies (and further
+   * into any methods those bodies call). A visited set keyed by MethodDefinition node prevents
+   * infinite loops on recursive methods.
    */
-  private checkUsageForDirectAccess(
-    constructorBody: ESTree.BlockStatement,
-    propsParamName: string,
-  ): void {
-    const directVisitor = new DirectPropsUsageVisitor(this.tracker, propsParamName);
-    traverseNodes(constructorBody, directVisitor);
-  }
-
-  /**
-   * Analyzes props usage via aliases within the constructor body.
-   *
-   * When props is assigned to another variable (alias), this method tracks
-   * usage of that alias throughout the constructor.
-   *
-   * @example
-   * ```typescript
-   * constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *   super(scope, id);
-   *   const p = props;  // <- Alias assignment detected
-   *   console.log(p.bucketName);  // <- Usage tracked here
-   * }
-   * ```
-   *
-   * @param constructorBody - The constructor's BlockStatement to analyze
-   * @param propsParamName - The name of the props parameter (e.g., "props")
-   */
-  private checkUsageForAliasAccess(
-    constructorBody: ESTree.BlockStatement,
-    propsParamName: string,
-  ): void {
-    const aliasVisitor = new PropsAliasVisitor(this.tracker, propsParamName);
-    traverseNodes(constructorBody, aliasVisitor);
-  }
-
-  /**
-   * Analyzes the class body for props usage via instance variables.
-   *
-   * When props is assigned to an instance variable (e.g., `this.myProps = props`),
-   * this method tracks usage of that instance variable throughout the entire class.
-   *
-   * @example
-   * ```typescript
-   * class MyConstruct extends Construct {
-   *   private myProps: MyConstructProps;
-   *
-   *   constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *     super(scope, id);
-   *     this.myProps = props;  // <- Instance variable assignment detected
-   *   }
-   *
-   *   someMethod() {
-   *     console.log(this.myProps.bucketName);  // <- Usage tracked here
-   *   }
-   * }
-   * ```
-   *
-   * @param classBody - The ClassBody node to analyze
-   * @param constructor - The constructor MethodDefinition node
-   * @param propsParamName - The name of the props parameter (e.g., "props")
-   */
-  private checkUsageForInstanceVariable(
+  private analyzeTransitiveMethodCalls(
+    body: ESTree.BlockStatement,
     classBody: ESTree.ClassBody,
-    constructor: ESTree.MethodDefinition,
-    propsParamName: string,
-  ) {
-    if (!constructor.value.body) return;
-    const instanceVarName = this.findPropsInstanceVariable(constructor.value.body, propsParamName);
-    if (!instanceVarName) return;
-
-    const instanceVisitor = new InstanceVariableUsageVisitor(this.tracker, instanceVarName);
-    traverseNodes(classBody, instanceVisitor);
-  }
-
-  /**
-   * Analyzes private methods that are called from the constructor with props as an argument.
-   *
-   * When a constructor calls a private method and passes props to it, this method
-   * finds the method definition and analyzes the props usage within that method.
-   *
-   * @example
-   * ```typescript
-   * class MyConstruct extends Construct {
-   *   constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *     super(scope, id);
-   *     this.setupBucket(props);  // <- Method call with props detected
-   *   }
-   *
-   *   private setupBucket(p: MyConstructProps) {
-   *     // Props usage in this method body is analyzed
-   *     new Bucket(this, 'Bucket', { bucketName: p.bucketName });
-   *   }
-   * }
-   * ```
-   *
-   * @param constructorBody - The constructor's BlockStatement to search for method calls
-   * @param classBody - The ClassBody containing method definitions
-   * @param propsParamName - The name of the props parameter (e.g., "props")
-   */
-  private checkUsageForPrivateMethodsCalledFromConstructor(
-    constructorBody: ESTree.BlockStatement,
-    classBody: ESTree.ClassBody,
-    propsParamName: string,
+    paramName: string,
+    visited: Set<ESTree.MethodDefinition>,
   ): void {
-    // NOTE: Collect method calls in constructor
-    const methodCallsWithProps = this.collectMethodCallsWithProps(constructorBody, propsParamName);
+    const methodCalls = this.collectMethodCallsWithProps(body, paramName);
 
-    // NOTE: For each method call, find the method definition and analyze it
-    for (const { methodName, propsArgIndices } of methodCallsWithProps) {
+    for (const { methodName, propsArgIndices } of methodCalls) {
       const methodDef = this.findMethodDefinition(classBody, methodName);
       if (!methodDef?.value.body) continue;
+      if (visited.has(methodDef)) continue;
+      visited.add(methodDef);
 
-      // NOTE: Get the actual parameter names from the method definition
       for (const argIndex of propsArgIndices) {
         const param = methodDef.value.params[argIndex];
-        if (param?.type === AST_NODE_TYPES.Identifier) {
-          const visitor = new DirectPropsUsageVisitor(this.tracker, param.name);
-          traverseNodes(methodDef.value.body, visitor);
-        }
+        if (param?.type !== AST_NODE_TYPES.Identifier) continue;
+        this.analyzeBlockForBinding(methodDef.value.body, param.name);
+        this.analyzeTransitiveMethodCalls(methodDef.value.body, classBody, param.name, visited);
       }
     }
   }
 
-  /**
-   * Collects method calls in the constructor body where props is passed as an argument.
-   *
-   * Uses `MethodCallCollectorVisitor` to traverse the constructor body and find
-   * all `this.methodName(props)` patterns.
-   *
-   * @example
-   * ```typescript
-   * constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *   super(scope, id);
-   *   this.setupBucket(props);        // <- Collected: { methodName: "setupBucket", propsArgIndices: [0] }
-   *   this.configure(config, props);  // <- Collected: { methodName: "configure", propsArgIndices: [1] }
-   * }
-   * ```
-   *
-   * @param body - The constructor's BlockStatement to traverse
-   * @param propsParamName - The name of the props parameter (e.g., "props")
-   * @returns Array of method call info with method names and argument indices where props appears
-   */
   private collectMethodCallsWithProps(
     body: ESTree.BlockStatement,
     propsParamName: string,
@@ -232,86 +129,36 @@ export class PropsUsageAnalyzer implements IPropsUsageAnalyzer {
   }
 
   /**
-   * Finds the instance variable name where props is assigned in the constructor.
-   *
-   * This method detects the pattern where props is stored in an instance variable
-   * for later access within the class.
-   *
-   * @example
-   * ```typescript
-   * class MyConstruct extends Construct {
-   *   private myProps: MyConstructProps;
-   *
-   *   constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *     super(scope, id);
-   *     this.myProps = props;  // <- This pattern is detected
-   *   }
-   * }
-   * ```
-   *
-   * AST structure for `this.myProps = props`:
-   *   ExpressionStatement
-   *   └── expression: AssignmentExpression
-   *       ├── left: MemberExpression
-   *       │   ├── object: ThisExpression
-   *       │   └── property: Identifier (name: "myProps" - returned value)
-   *       └── right: Identifier (name: "props" === propsParamName)
-   *
-   * @param body - The constructor's BlockStatement to analyze
-   * @param propsParamName - The name of the props parameter (e.g., "props")
-   * @returns The instance variable name (e.g., "myProps") or null if not found
+   * Detects `this.<name> = props` or `this.#<name> = props` in the constructor's top-level
+   * statements. Returns the field's name and whether it is a `#`-prefixed private field.
    */
   private findPropsInstanceVariable(
     body: ESTree.BlockStatement,
     propsParamName: string,
-  ): string | null {
+  ): InstanceVarBinding | null {
     for (const statement of body.body) {
+      if (statement.type !== AST_NODE_TYPES.ExpressionStatement) continue;
+      const expression = statement.expression;
+      if (expression.type !== AST_NODE_TYPES.AssignmentExpression) continue;
       if (
-        statement.type === AST_NODE_TYPES.ExpressionStatement &&
-        statement.expression.type === AST_NODE_TYPES.AssignmentExpression &&
-        statement.expression.left.type === AST_NODE_TYPES.MemberExpression &&
-        statement.expression.left.object.type === AST_NODE_TYPES.ThisExpression &&
-        statement.expression.left.property.type === AST_NODE_TYPES.Identifier &&
-        statement.expression.right.type === AST_NODE_TYPES.Identifier &&
-        statement.expression.right.name === propsParamName
+        expression.right.type !== AST_NODE_TYPES.Identifier ||
+        expression.right.name !== propsParamName
       ) {
-        return statement.expression.left.property.name;
+        continue;
+      }
+      const left = expression.left;
+      if (left.type !== AST_NODE_TYPES.MemberExpression) continue;
+      if (left.object.type !== AST_NODE_TYPES.ThisExpression) continue;
+      if (left.property.type === AST_NODE_TYPES.Identifier) {
+        return { name: left.property.name, isPrivateField: false };
+      }
+      if (left.property.type === AST_NODE_TYPES.PrivateIdentifier) {
+        return { name: left.property.name, isPrivateField: true };
       }
     }
     return null;
   }
 
-  /**
-   * Finds a method definition in the class body by its name.
-   *
-   * This method is used to locate the actual method implementation when
-   * a method call like `this.someMethod(props)` is found in the constructor.
-   *
-   * @example
-   * ```typescript
-   * class MyConstruct extends Construct {
-   *   constructor(scope: Construct, id: string, props: MyConstructProps) {
-   *     super(scope, id);
-   *     this.setupBucket(props);  // <- Method call detected
-   *   }
-   *
-   *   private setupBucket(p: MyConstructProps) {  // <- This definition is found
-   *     new Bucket(this, 'Bucket', { bucketName: p.bucketName });
-   *   }
-   * }
-   * ```
-   *
-   * AST structure for method definition:
-   *   MethodDefinition
-   *   ├── key: Identifier (name: "setupBucket" === methodName)
-   *   └── value: FunctionExpression
-   *       ├── params: [Identifier, ...]
-   *       └── body: BlockStatement
-   *
-   * @param classBody - The ClassBody node containing all class members
-   * @param methodName - The name of the method to find (e.g., "setupBucket")
-   * @returns The MethodDefinition node or null if not found
-   */
   private findMethodDefinition(
     classBody: ESTree.ClassBody,
     methodName: string,

--- a/packages/oxlint/src/rules/no-unused-props/props-usage-tracker.ts
+++ b/packages/oxlint/src/rules/no-unused-props/props-usage-tracker.ts
@@ -88,25 +88,20 @@ export class PropsUsageTracker implements IPropsUsageTracker {
     node: ESTree.MemberExpression,
     propsParamName: string,
   ): void {
-    // NOTE: Check for props.propertyName or props?.propertyName pattern
-    if (
-      node.object.type === AST_NODE_TYPES.Identifier &&
-      node.object.name === propsParamName &&
-      node.property.type === AST_NODE_TYPES.Identifier
-    ) {
-      this.markAsUsed(node.property.name);
+    // NOTE: props.x / props?.x / props["x"] / props[<other>]
+    if (node.object.type === AST_NODE_TYPES.Identifier && node.object.name === propsParamName) {
+      this.markPropertyFromAccess(node);
       return;
     }
 
-    // NOTE: Check for this.props.propertyName or this.props?.propertyName pattern
+    // NOTE: this.props.x / this.props?.x / this.props["x"] (parameter-property style bindings)
     if (
       node.object.type === AST_NODE_TYPES.MemberExpression &&
       node.object.object.type === AST_NODE_TYPES.ThisExpression &&
       node.object.property.type === AST_NODE_TYPES.Identifier &&
-      node.object.property.name === propsParamName &&
-      node.property.type === AST_NODE_TYPES.Identifier
+      node.object.property.name === propsParamName
     ) {
-      this.markAsUsed(node.property.name);
+      this.markPropertyFromAccess(node);
       return;
     }
   }
@@ -115,7 +110,6 @@ export class PropsUsageTracker implements IPropsUsageTracker {
     node: ESTree.VariableDeclarator,
     propsParamName: string,
   ): void {
-    // NOTE: Check for destructuring assignment: const { prop1, prop2 } = props
     if (
       node.id.type !== AST_NODE_TYPES.ObjectPattern ||
       node.init?.type !== AST_NODE_TYPES.Identifier ||
@@ -124,9 +118,13 @@ export class PropsUsageTracker implements IPropsUsageTracker {
       return;
     }
 
-    const names = findPropertyNames(node.id.properties);
-    for (const name of names) {
+    for (const name of findPropertyNames(node.id.properties)) {
       this.markAsUsed(name);
+    }
+    // NOTE: `const { a, ...rest } = props` — the rest binding captures the remaining
+    // properties opaquely, so treat them all as used
+    if (node.id.properties.some((p) => p.type === AST_NODE_TYPES.RestElement)) {
+      this.markAllAsUsed();
     }
   }
 
@@ -145,9 +143,27 @@ export class PropsUsageTracker implements IPropsUsageTracker {
     }
 
     this.markAsUsed(node.right.property.name);
+  }
 
-    // NOTE: this.props = props pattern doesn't mark all properties as used
-    // because we still need to check which properties are actually accessed later
+  /**
+   * Marks the property targeted by the given member expression's `property` node. Falls back to
+   * marking all properties when the access is computed with a non-string-literal key.
+   */
+  private markPropertyFromAccess(node: ESTree.MemberExpression): void {
+    const property = node.property;
+    if (!node.computed && property.type === AST_NODE_TYPES.Identifier) {
+      this.markAsUsed(property.name);
+      return;
+    }
+    if (
+      node.computed &&
+      property.type === AST_NODE_TYPES.Literal &&
+      typeof property.value === "string"
+    ) {
+      this.markAsUsed(property.value);
+      return;
+    }
+    this.markAllAsUsed();
   }
 
   /**

--- a/packages/oxlint/src/rules/no-unused-props/visitor/direct-props-usage-visitor.ts
+++ b/packages/oxlint/src/rules/no-unused-props/visitor/direct-props-usage-visitor.ts
@@ -1,29 +1,21 @@
 import type { ESTree } from "corsa-oxlint";
 
-import { AST_NODE_TYPES } from "corsa-oxlint";
-
 import { IPropsUsageTracker } from "../props-usage-tracker";
 import { INodeVisitor } from "./interface/node-visitor";
+import { isTrackedFormForBareIdentifier } from "./is-tracked-form";
 
 /**
  * Visitor that tracks direct usage of the props parameter.
  *
- * This visitor detects various patterns where props is accessed directly:
- * - `props.bucketName` - Property access
- * - `const { bucketName } = props` - Destructuring assignment
- * - `this.bucketName = props.bucketName` - Assignment expression
- * - `console.log(props)` - Whole object usage (marks all properties as used)
+ * The per-property tracked forms are:
+ * - `props.x` / `props?.x` / `props["x"]`      (MemberExpression)
+ * - `const { x } = props`                       (VariableDeclarator, destructuring)
+ * - `const alias = props`                       (VariableDeclarator, alias — handled by PropsAliasVisitor)
+ * - `this.x = props` / `this.#x = props`        (AssignmentExpression — handled by analyzer)
+ * - `this.method(props)`                        (CallExpression — handled by analyzer)
  *
- * @example
- * ```typescript
- * constructor(scope: Construct, id: string, props: MyConstructProps) {
- *   super(scope, id);
- *   const name = props.bucketName;           // <- Detected by visitMemberExpression
- *   const { enableVersioning } = props;      // <- Detected by visitVariableDeclarator
- *   this.name = props.bucketName;            // <- Detected by visitAssignmentExpression
- *   console.log(props);                      // <- Detected by visitIdentifier (marks all)
- * }
- * ```
+ * Any other occurrence of a bare `props` identifier is treated as a whole-object escape:
+ * all properties are marked as used.
  */
 export class DirectPropsUsageVisitor implements INodeVisitor {
   constructor(
@@ -44,103 +36,8 @@ export class DirectPropsUsageVisitor implements INodeVisitor {
   }
 
   visitIdentifier(node: ESTree.Identifier): void {
-    /**
-     * Handles cases where the props identifier is used as a whole value.
-     *
-     * This method detects when `props` (or the configured propsParamName) is used
-     * in contexts where all properties should be marked as used, because we cannot
-     * statically determine which properties will be accessed at runtime.
-     *
-     * Handled patterns:
-     *
-     * 1. **External function call** (`someFunction(props)` or `console.log(props)`):
-     *    - Marks ALL properties as used
-     *    - Excludes `this.method(props)` which is handled by analyzePrivateMethodsCalledFromConstructor
-     *
-     *    AST structure:
-     *      CallExpression
-     *      ├── callee: Identifier (someFunction) or MemberExpression (console.log)
-     *      └── arguments: [Identifier (name: "props")]
-     *
-     * 2. **Return statement** (`return props`):
-     *    - Marks ALL properties as used
-     *
-     *    AST structure:
-     *      ReturnStatement
-     *      └── argument: Identifier (name: "props")
-     *
-     * 3. **Array element** (`[props]` or `[a, props, b]`):
-     *    - Marks ALL properties as used
-     *
-     *    AST structure:
-     *      ArrayExpression
-     *      └── elements: [..., Identifier (name: "props"), ...]
-     *
-     * 4. **Object property value** (`{ key: props }`):
-     *    - Marks ALL properties as used
-     *
-     *    AST structure:
-     *      Property
-     *      ├── key: Identifier (name: "key")
-     *      └── value: Identifier (name: "props")
-     *
-     * The following cases are intentionally excluded (handled elsewhere):
-     * - `props.xxx` (MemberExpression) - handled by visitMemberExpression
-     * - `const { xxx } = props` (VariableDeclarator with ObjectPattern) - handled by visitVariableDeclarator
-     * - `this.xxx = props.xxx` (AssignmentExpression) - handled by visitAssignmentExpression
-     * - `this.method(props)` (CallExpression with ThisExpression callee) - handled by analyzePrivateMethodsCalledFromConstructor
-     * - `const a = props` (alias registration) - handled by PropsAliasVisitor
-     */
-
-    // NOTE: Check if props object is used as a whole (e.g., console.log(props))
     if (node.name !== this.propsParamName) return;
-
-    const parent = node.parent;
-    if (!parent) return;
-
-    switch (parent.type) {
-      // NOTE: Pattern 1: External function call
-      case AST_NODE_TYPES.CallExpression: {
-        if (!parent.arguments.some((arg) => arg === node)) return;
-        if (
-          parent.callee.type === AST_NODE_TYPES.MemberExpression &&
-          parent.callee.object.type === AST_NODE_TYPES.ThisExpression
-        ) {
-          return;
-        }
-        this.tracker.markAllAsUsed();
-        return;
-      }
-
-      // NOTE: Pattern 2: Return statement
-      case AST_NODE_TYPES.ReturnStatement: {
-        // NOTE: return props - props as a whole
-        if (parent.argument === node) {
-          this.tracker.markAllAsUsed();
-        }
-        return;
-      }
-
-      // NOTE: Pattern 3: Array element
-      case AST_NODE_TYPES.ArrayExpression: {
-        // NOTE: [props] - props as a whole
-        if (parent.elements.some((el) => el === node)) {
-          this.tracker.markAllAsUsed();
-        }
-        return;
-      }
-
-      // NOTE: Pattern 4: Object property value
-      case AST_NODE_TYPES.Property: {
-        // NOTE: { key: props } - props as a whole
-        if (parent.value === node) {
-          this.tracker.markAllAsUsed();
-        }
-        return;
-      }
-      default: {
-        return;
-      }
-    }
+    if (isTrackedFormForBareIdentifier(node)) return;
+    this.tracker.markAllAsUsed();
   }
 }

--- a/packages/oxlint/src/rules/no-unused-props/visitor/instance-variable-usage-visitor.ts
+++ b/packages/oxlint/src/rules/no-unused-props/visitor/instance-variable-usage-visitor.ts
@@ -6,107 +6,58 @@ import { IPropsUsageTracker } from "../props-usage-tracker";
 import { INodeVisitor } from "./interface/node-visitor";
 
 /**
- * Visitor that tracks props usage through instance variables.
- *
- * When props is assigned to an instance variable (e.g., `this.myProps = props`),
- * this visitor tracks property access on that instance variable throughout the class.
- *
- * Handles two patterns:
- * 1. Property access: `this.myProps.bucketName` - marks specific property as used
- * 2. Whole object usage: `console.log(this.myProps)` - marks all properties as used
- *
- * @example
- * ```typescript
- * class MyConstruct extends Construct {
- *   private myProps: MyConstructProps;
- *
- *   constructor(scope: Construct, id: string, props: MyConstructProps) {
- *     super(scope, id);
- *     this.myProps = props;
- *   }
- *
- *   someMethod() {
- *     console.log(this.myProps.bucketName);  // <- 'bucketName' is marked as used
- *   }
- * }
- * ```
+ * Tracks props usage through an instance field (`this.myProps` or `this.#myProps`) that
+ * mirrors the props parameter.
  */
 export class InstanceVariableUsageVisitor implements INodeVisitor {
   constructor(
     private readonly tracker: IPropsUsageTracker,
     private readonly instanceVarName: string,
+    private readonly isPrivateField: boolean = false,
   ) {}
 
   visitMemberExpression(node: ESTree.MemberExpression): void {
-    // ===========================================================================
-    // Pattern 1: Property access - this.instanceVarName.propertyName
-    // ===========================================================================
-    // Matches code like: `console.log(this.myProps.bucketName)` or `return this.myProps.enableVersioning`
-    //
-    // AST structure:
-    //   MemberExpression (node)
-    //   ├── object: MemberExpression (this.myProps)
-    //   │   ├── object: ThisExpression
-    //   │   └── property: Identifier (name: "myProps" === instanceVarName)
-    //   └── property: Identifier (name: "bucketName" - the property being accessed)
-    //
-    // When this pattern matches, we mark the accessed property (e.g., "bucketName") as used.
     if (
-      node.type === AST_NODE_TYPES.MemberExpression &&
       node.object.type === AST_NODE_TYPES.MemberExpression &&
-      node.object.object.type === AST_NODE_TYPES.ThisExpression &&
-      node.object.property.type === AST_NODE_TYPES.Identifier &&
-      node.object.property.name === this.instanceVarName &&
-      node.property.type === AST_NODE_TYPES.Identifier
+      this.isMatchingThisMember(node.object)
     ) {
-      this.tracker.markAsUsed(node.property.name);
+      this.markProperty(node);
       return;
     }
 
-    // ===========================================================================
-    // Pattern 2: Whole object usage - this.instanceVarName used as a value
-    // ===========================================================================
-    // Matches code like: `console.log(this.myProps)` or `return this.myProps`
-    //
-    // AST structure:
-    //   MemberExpression (node)
-    //   ├── object: ThisExpression
-    //   └── property: Identifier (name: "myProps" === instanceVarName)
-    //
-    // However, we need to exclude certain cases where `this.myProps` appears
-    // but isn't actually being "used as a value":
-    //
-    // Exclusion A: Property access (handled by Pattern 1 above)
-    //   Code: `this.myProps.bucketName`
-    //   The `this.myProps` part has parent MemberExpression where it's the object
-    //
-    // Exclusion B: Assignment left-hand side
-    //   Code: `this.myProps = props`
-    //   The `this.myProps` is being assigned to, not used as a value
-    if (
-      node.type === AST_NODE_TYPES.MemberExpression &&
-      node.object.type === AST_NODE_TYPES.ThisExpression &&
-      node.property.type === AST_NODE_TYPES.Identifier &&
-      node.property.name === this.instanceVarName
-    ) {
+    if (this.isMatchingThisMember(node)) {
       const parent = node.parent;
-
-      // NOTE: Exclusion A - Skip if this is part of a property access (this.myProps.xxx)
-      // The parent MemberExpression's object being this node means we're accessing a property
-      if (parent?.type === AST_NODE_TYPES.MemberExpression && parent.object === node) {
-        return;
-      }
-
-      // NOTE: Exclusion B - Skip if this is the left side of an assignment (this.myProps = ...)
-      if (parent?.type === AST_NODE_TYPES.AssignmentExpression && parent.left === node) {
-        return;
-      }
-
-      // NOTE: If we reach here, `this.myProps` is used as a whole value
-      // Examples: console.log(this.myProps), return this.myProps, [this.myProps], etc.
-      // Since we can't know which properties will be accessed at runtime, mark all as used
+      if (parent?.type === AST_NODE_TYPES.MemberExpression && parent.object === node) return;
+      if (parent?.type === AST_NODE_TYPES.AssignmentExpression && parent.left === node) return;
       this.tracker.markAllAsUsed();
+    }
+  }
+
+  private isMatchingThisMember(node: ESTree.MemberExpression): boolean {
+    if (node.object.type !== AST_NODE_TYPES.ThisExpression) return false;
+    const property = node.property;
+    if (this.isPrivateField) {
+      return (
+        property.type === AST_NODE_TYPES.PrivateIdentifier && property.name === this.instanceVarName
+      );
+    }
+    return property.type === AST_NODE_TYPES.Identifier && property.name === this.instanceVarName;
+  }
+
+  private markProperty(node: ESTree.MemberExpression): void {
+    const property = node.property;
+    if (!node.computed && property.type === AST_NODE_TYPES.Identifier) {
+      this.tracker.markAsUsed(property.name);
       return;
     }
+    if (
+      node.computed &&
+      property.type === AST_NODE_TYPES.Literal &&
+      typeof property.value === "string"
+    ) {
+      this.tracker.markAsUsed(property.value);
+      return;
+    }
+    this.tracker.markAllAsUsed();
   }
 }

--- a/packages/oxlint/src/rules/no-unused-props/visitor/is-tracked-form.ts
+++ b/packages/oxlint/src/rules/no-unused-props/visitor/is-tracked-form.ts
@@ -1,0 +1,77 @@
+import type { ESTree } from "corsa-oxlint";
+
+import { AST_NODE_TYPES } from "corsa-oxlint";
+
+/**
+ * Returns true when the given identifier does NOT need to be marked as a whole-object escape,
+ * either because it is not a value reference at all (e.g. a property key like `this.props`)
+ * or because it appears in a form whose per-property usage is tracked precisely elsewhere in
+ * the analyzer.
+ *
+ * Any other position is a whole-object escape and should mark all properties as used.
+ */
+export const isTrackedFormForBareIdentifier = (node: ESTree.Identifier): boolean => {
+  const parent = node.parent;
+  if (!parent) return true;
+
+  if (isNonReferencePosition(node, parent)) return true;
+
+  switch (parent.type) {
+    // NOTE: `props.x` / `props?.x` / `props["x"]`
+    case AST_NODE_TYPES.MemberExpression: {
+      return parent.object === node;
+    }
+    // NOTE: `const x = props` / `const { x } = props`
+    case AST_NODE_TYPES.VariableDeclarator: {
+      return parent.init === node;
+    }
+    // NOTE: `this.x = props` / `this.#x = props`
+    case AST_NODE_TYPES.AssignmentExpression: {
+      return parent.right === node && isThisMemberLeft(parent.left);
+    }
+    // NOTE: `this.method(props)`
+    case AST_NODE_TYPES.CallExpression: {
+      return isThisMethodCall(parent) && parent.arguments.some((arg) => arg === node);
+    }
+    default: {
+      return false;
+    }
+  }
+};
+
+const isNonReferencePosition = (node: ESTree.Identifier, parent: ESTree.Node): boolean => {
+  switch (parent.type) {
+    case AST_NODE_TYPES.MemberExpression: {
+      return !parent.computed && parent.property === node;
+    }
+    case AST_NODE_TYPES.Property: {
+      return !parent.computed && !parent.shorthand && parent.key === node;
+    }
+    case AST_NODE_TYPES.MethodDefinition:
+    case AST_NODE_TYPES.PropertyDefinition:
+    case AST_NODE_TYPES.TSPropertySignature:
+    case AST_NODE_TYPES.TSMethodSignature: {
+      return !parent.computed && parent.key === node;
+    }
+    default: {
+      return false;
+    }
+  }
+};
+
+const isThisMemberLeft = (left: ESTree.Node): boolean => {
+  if (left.type !== AST_NODE_TYPES.MemberExpression) return false;
+  if (left.object.type !== AST_NODE_TYPES.ThisExpression) return false;
+  return (
+    left.property.type === AST_NODE_TYPES.Identifier ||
+    left.property.type === AST_NODE_TYPES.PrivateIdentifier
+  );
+};
+
+const isThisMethodCall = (call: ESTree.CallExpression): boolean => {
+  const callee = call.callee;
+  return (
+    callee.type === AST_NODE_TYPES.MemberExpression &&
+    callee.object.type === AST_NODE_TYPES.ThisExpression
+  );
+};

--- a/packages/oxlint/src/rules/no-unused-props/visitor/is-tracked-form.ts
+++ b/packages/oxlint/src/rules/no-unused-props/visitor/is-tracked-form.ts
@@ -39,6 +39,34 @@ export const isTrackedFormForBareIdentifier = (node: ESTree.Identifier): boolean
   }
 };
 
+/**
+ * Narrower tracked-form check for alias identifiers (variables bound via `const a = props`).
+ *
+ * Aliases are only tracked when they appear as a member-access object (`a.x`) or as the RHS of
+ * a destructuring declaration (`const { x } = a`). Every other position — including plain
+ * `const b = a`, `this.x = a`, `this.m(a)` — is treated as a whole-object escape because there
+ * is no alias-of-alias, instance-variable, or method-call tracking for aliased references.
+ */
+export const isTrackedFormForAliasIdentifier = (node: ESTree.Identifier): boolean => {
+  const parent = node.parent;
+  if (!parent) return true;
+
+  if (isNonReferencePosition(node, parent)) return true;
+
+  switch (parent.type) {
+    case AST_NODE_TYPES.MemberExpression: {
+      return parent.object === node;
+    }
+    case AST_NODE_TYPES.VariableDeclarator: {
+      // NOTE: destructuring `const { x } = alias` is tracked; plain `const b = alias` is not.
+      return parent.init === node && parent.id.type === AST_NODE_TYPES.ObjectPattern;
+    }
+    default: {
+      return false;
+    }
+  }
+};
+
 const isNonReferencePosition = (node: ESTree.Identifier, parent: ESTree.Node): boolean => {
   switch (parent.type) {
     case AST_NODE_TYPES.MemberExpression: {
@@ -70,8 +98,12 @@ const isThisMemberLeft = (left: ESTree.Node): boolean => {
 
 const isThisMethodCall = (call: ESTree.CallExpression): boolean => {
   const callee = call.callee;
+  // NOTE: computed calls (`this["m"](props)`) are not collected by MethodCallCollectorVisitor,
+  // so they must fall through to the whole-object escape path.
   return (
     callee.type === AST_NODE_TYPES.MemberExpression &&
-    callee.object.type === AST_NODE_TYPES.ThisExpression
+    !callee.computed &&
+    callee.object.type === AST_NODE_TYPES.ThisExpression &&
+    callee.property.type === AST_NODE_TYPES.Identifier
   );
 };

--- a/packages/oxlint/src/rules/no-unused-props/visitor/props-alias-visitor.ts
+++ b/packages/oxlint/src/rules/no-unused-props/visitor/props-alias-visitor.ts
@@ -4,22 +4,13 @@ import { AST_NODE_TYPES } from "corsa-oxlint";
 
 import { IPropsUsageTracker } from "../props-usage-tracker";
 import { INodeVisitor } from "./interface/node-visitor";
+import { isTrackedFormForBareIdentifier } from "./is-tracked-form";
 
 /**
- * Visitor that tracks props usage through variable aliases.
+ * Tracks props usage through variable aliases.
  *
- * When props is assigned to another variable (alias), this visitor:
- * 1. Registers the alias when `const myProps = props` is detected
- * 2. Tracks property access on the alias like `myProps.bucketName`
- *
- * @example
- * ```typescript
- * constructor(scope: Construct, id: string, props: MyConstructProps) {
- *   super(scope, id);
- *   const myProps = props;              // <- Alias 'myProps' is registered
- *   console.log(myProps.bucketName);    // <- 'bucketName' is marked as used
- * }
- * ```
+ * `const alias = props` registers `alias`, and the same tracked-form / whole-escape rules
+ * used for `props` itself are then applied to occurrences of `alias`.
  */
 export class PropsAliasVisitor implements INodeVisitor {
   private readonly aliases = new Set<string>();
@@ -31,48 +22,32 @@ export class PropsAliasVisitor implements INodeVisitor {
 
   visitMemberExpression(node: ESTree.MemberExpression): void {
     this.tracker.markAsUsedForMemberExpression(node, this.propsParamName);
-    /**
-     * NOTE: Check if the object is an alias of props
-     * ```ts
-     * const myProps = props;
-     * console.log(myProps.bucketName); // <- detect this access
-     * ```
-     */
-    if (
-      node.object.type === AST_NODE_TYPES.Identifier &&
-      this.aliases.has(node.object.name) &&
-      node.property.type === AST_NODE_TYPES.Identifier
-    ) {
-      this.tracker.markAsUsed(node.property.name);
+    if (node.object.type === AST_NODE_TYPES.Identifier && this.aliases.has(node.object.name)) {
+      this.tracker.markAsUsedForMemberExpression(node, node.object.name);
+    }
+  }
+
+  visitVariableDeclarator(node: ESTree.VariableDeclarator): void {
+    if (node.init?.type !== AST_NODE_TYPES.Identifier) return;
+    if (this.aliases.has(node.init.name)) {
+      this.tracker.markAsUsedForVariableDeclarator(node, node.init.name);
     }
   }
 
   visitIdentifier(node: ESTree.Identifier): void {
-    /**
-     * Handles alias registration for props.
-     *
-     * This method detects when props is assigned to a simple variable,
-     * which creates an alias that should be tracked for property access.
-     *
-     * Handled pattern:
-     *
-     * **Variable assignment** (`const myProps = props`):
-     *    - Registers 'myProps' as an alias of props
-     *    - Later access like `myProps.bucketName` will be detected by visitMemberExpression
-     *
-     *    AST structure:
-     *      VariableDeclarator
-     *      ├── id: Identifier (name: "myProps" - the alias to register)
-     *      └── init: Identifier (name: "props")
-     */
-    if (node.name !== this.propsParamName) return;
+    if (node.name === this.propsParamName) {
+      this.registerAliasIfDeclaration(node);
+      return;
+    }
+    if (!this.aliases.has(node.name)) return;
+    if (isTrackedFormForBareIdentifier(node)) return;
+    this.tracker.markAllAsUsed();
+  }
 
+  private registerAliasIfDeclaration(node: ESTree.Identifier): void {
     const parent = node.parent;
-    if (!parent) return;
-
-    // NOTE: const myProps = props - track 'myProps' as an alias of props
     if (
-      parent.type === AST_NODE_TYPES.VariableDeclarator &&
+      parent?.type === AST_NODE_TYPES.VariableDeclarator &&
       parent.init === node &&
       parent.id.type === AST_NODE_TYPES.Identifier
     ) {

--- a/packages/oxlint/src/rules/no-unused-props/visitor/props-alias-visitor.ts
+++ b/packages/oxlint/src/rules/no-unused-props/visitor/props-alias-visitor.ts
@@ -4,7 +4,7 @@ import { AST_NODE_TYPES } from "corsa-oxlint";
 
 import { IPropsUsageTracker } from "../props-usage-tracker";
 import { INodeVisitor } from "./interface/node-visitor";
-import { isTrackedFormForBareIdentifier } from "./is-tracked-form";
+import { isTrackedFormForAliasIdentifier } from "./is-tracked-form";
 
 /**
  * Tracks props usage through variable aliases.
@@ -40,7 +40,7 @@ export class PropsAliasVisitor implements INodeVisitor {
       return;
     }
     if (!this.aliases.has(node.name)) return;
-    if (isTrackedFormForBareIdentifier(node)) return;
+    if (isTrackedFormForAliasIdentifier(node)) return;
     this.tracker.markAllAsUsed();
   }
 


### PR DESCRIPTION
### Issue # (if applicable)

Closes #532.

### Reason for this change

`no-unused-props` recognized only a narrow whitelist of AST shapes as usage, so idiomatic CDK patterns — passing whole props to a `NewExpression`, spread, alias consumed as a whole, the `in` operator, rest destructuring, string-literal computed access, `#private` field storage, and transitive `this.method(props)` chains — all produced false positives.

### Description of changes

Invert the whitelist (mirrored in both plugins): only precisely trackable forms (member access, alias, instance-variable storage, `this.method(props)` calls, destructuring) are analyzed per property, and **any other occurrence of the bare props identifier is a whole-object escape that marks all properties as used**, structurally eliminating the missing-parent-kind bug class. The precise trackers are strengthened to uphold this invariant: string-literal computed access marks the named property (opaque keys mark all, fixing the mistaken variable-name marking), `RestElement` marks the remaining properties, instance-variable bindings are collected by traversal (nested / multiple / `#private` fields) and also inside transitively analyzed method bodies, method following recurses with a per-`(method, arg-index)` visited set and skips overload signatures, and any call that cannot be resolved to an analyzable method falls back to marking all properties used.

### Description of how you validated changes

- Added valid cases for all 8 false-positive patterns from the issue, plus escape-path cases found in review (inherited/computed method calls, alias escapes, nested and multiple instance-variable bindings), and invalid cases pinning that precision is retained (string-literal computed access, transitive chains, and instance-variable storage still report genuinely unused properties). 25 new cases per plugin.
- All pre-existing test expectations are unchanged; `vp check` and `vp test --run` (646/646) pass.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_