### PR TITLE
fix: validate expression-less template literal ids in no-parent-name-construct-id-match

### DIFF
--- a/packages/eslint/src/__tests__/no-parent-name-construct-id-match.test.ts
+++ b/packages/eslint/src/__tests__/no-parent-name-construct-id-match.test.ts
@@ -114,6 +114,42 @@ ruleTester.run("no-parent-name-construct-id-match", noParentNameConstructIdMatch
         }
       }`,
     },
+    // WHEN: construct id is a template literal without expressions
+    //       and does not match parent construct name
+    {
+      code: `
+      class Construct {}
+      class SampleClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new SampleClass(scope, \`ValidId\`);
+        }
+      }`,
+    },
+    // WHEN: construct id is a template literal with expressions (dynamic)
+    //       and disallowContainingParentName is true
+    {
+      code: `
+      class Construct {}
+      class SampleClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const suffix = "x";
+          new SampleClass(scope, \`TestClass\${suffix}\`);
+        }
+      }`,
+      options: [{ disallowContainingParentName: true }],
+    },
   ],
   invalid: [
     // WHEN: in method
@@ -389,6 +425,43 @@ ruleTester.run("no-parent-name-construct-id-match", noParentNameConstructIdMatch
         }
       }`,
       errors: [{ messageId: "invalidConstructId" }],
+    },
+    // WHEN: construct id is a template literal without expressions
+    //       and matches parent construct name
+    {
+      code: `
+      class Construct {}
+      class SampleClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new SampleClass(scope, \`TestClass\`);
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+    },
+    // WHEN: construct id is a template literal without expressions
+    //       that includes parent construct name, and disallowContainingParentName is true
+    {
+      code: `
+      class Construct {}
+      class SampleClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new SampleClass(scope, \`SampleTestClass\`);
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      options: [{ disallowContainingParentName: true }],
     },
   ],
 });

--- a/packages/eslint/src/rules/no-parent-name-construct-id-match.ts
+++ b/packages/eslint/src/rules/no-parent-name-construct-id-match.ts
@@ -1,5 +1,6 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
+import { ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
 
+import { findConstructIdString } from "../core/ast-node/finder/construct-id-string";
 import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isInsideConstructorOrMethod } from "../core/ast-node/finder/enclosing-method";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
@@ -94,11 +95,10 @@ const validateConstructId = ({
 }: ValidateConstructIdArgs): void => {
   // NOTE: Treat the second argument as ID
   const secondArg = node.arguments[1];
-  if (secondArg.type !== AST_NODE_TYPES.Literal || typeof secondArg.value !== "string") {
-    return;
-  }
+  const constructId = findConstructIdString(secondArg);
+  if (constructId === null) return;
 
-  const formattedConstructId = toPascalCase(secondArg.value);
+  const formattedConstructId = toPascalCase(constructId);
   const formattedParentClassName = toPascalCase(parentClassName);
 
   if (
@@ -109,7 +109,7 @@ const validateConstructId = ({
       node: secondArg,
       messageId: "invalidConstructId",
       data: {
-        constructId: secondArg.value,
+        constructId,
         parentConstructName: parentClassName,
       },
     });
@@ -120,7 +120,7 @@ const validateConstructId = ({
       node: secondArg,
       messageId: "invalidConstructId",
       data: {
-        constructId: secondArg.value,
+        constructId,
         parentConstructName: parentClassName,
       },
     });

--- a/packages/oxlint/src/__tests__/no-parent-name-construct-id-match.test.ts
+++ b/packages/oxlint/src/__tests__/no-parent-name-construct-id-match.test.ts
@@ -105,6 +105,42 @@ ruleTester.run("no-parent-name-construct-id-match", noParentNameConstructIdMatch
         }
       }`,
     },
+    // WHEN: construct id is a template literal without expressions
+    //       and does not match parent construct name
+    {
+      code: `
+      class Construct {}
+      class SampleClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new SampleClass(scope, \`ValidId\`);
+        }
+      }`,
+    },
+    // WHEN: construct id is a template literal with expressions (dynamic)
+    //       and disallowContainingParentName is true
+    {
+      code: `
+      class Construct {}
+      class SampleClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const suffix = "x";
+          new SampleClass(scope, \`TestClass\${suffix}\`);
+        }
+      }`,
+      options: [{ disallowContainingParentName: true }],
+    },
   ],
   invalid: [
     // WHEN: in method
@@ -380,6 +416,43 @@ ruleTester.run("no-parent-name-construct-id-match", noParentNameConstructIdMatch
         }
       }`,
       errors: [{ messageId: "invalidConstructId" }],
+    },
+    // WHEN: construct id is a template literal without expressions
+    //       and matches parent construct name
+    {
+      code: `
+      class Construct {}
+      class SampleClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new SampleClass(scope, \`TestClass\`);
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+    },
+    // WHEN: construct id is a template literal without expressions
+    //       that includes parent construct name, and disallowContainingParentName is true
+    {
+      code: `
+      class Construct {}
+      class SampleClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestClass extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new SampleClass(scope, \`SampleTestClass\`);
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      options: [{ disallowContainingParentName: true }],
     },
   ],
 });

--- a/packages/oxlint/src/rules/no-parent-name-construct-id-match.ts
+++ b/packages/oxlint/src/rules/no-parent-name-construct-id-match.ts
@@ -1,7 +1,8 @@
 import type { ESTree, RuleContext } from "corsa-oxlint";
 
-import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
+import { ESLintUtils } from "corsa-oxlint";
 
+import { findConstructIdString } from "../core/ast-node/finder/construct-id-string";
 import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isInsideConstructorOrMethod } from "../core/ast-node/finder/enclosing-method";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
@@ -94,11 +95,10 @@ const validateConstructId = ({
 }: ValidateConstructIdArgs): void => {
   // NOTE: Treat the second argument as ID
   const secondArg = node.arguments[1];
-  if (secondArg.type !== AST_NODE_TYPES.Literal || typeof secondArg.value !== "string") {
-    return;
-  }
+  const constructId = findConstructIdString(secondArg);
+  if (constructId === null) return;
 
-  const formattedConstructId = toPascalCase(secondArg.value);
+  const formattedConstructId = toPascalCase(constructId);
   const formattedParentClassName = toPascalCase(parentClassName);
 
   if (
@@ -109,7 +109,7 @@ const validateConstructId = ({
       node: secondArg,
       messageId: "invalidConstructId",
       data: {
-        constructId: secondArg.value,
+        constructId,
         parentConstructName: parentClassName,
       },
     });
@@ -120,7 +120,7 @@ const validateConstructId = ({
       node: secondArg,
       messageId: "invalidConstructId",
       data: {
-        constructId: secondArg.value,
+        constructId,
         parentConstructName: parentClassName,
       },
     });


### PR DESCRIPTION
### Issue # (if applicable)

Closes #562.

### Reason for this change

`no-parent-name-construct-id-match` only validated string-literal construct IDs, so an expression-less template literal (`` `MyConstruct` ``) — a static string with the same runtime value — silently bypassed the rule, unlike every other construct-ID rule in the suite.

### Description of changes

- Replaced the `Literal`-only check in `validateConstructId` with the shared `findConstructIdString` helper (the same helper `pascal-case-construct-id` / `no-construct-stack-suffix` adopted in #553), so expression-less template literals are validated while template literals with `${}` expressions remain skipped.
- Mirrored in both packages (eslint / oxlint).

### Description of how you validated changes

- Added regression tests to both packages: template-literal exact match and containing match (invalid), non-matching template literal and expression-containing template literal (valid).
- Verified the new invalid cases fail against the unpatched rule (4 failures), then pass with the fix.
- `vp check` and `vp test --run` (658 tests, 34 files) pass at the repo root.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
