### PR TITLE
fix: recognize public parameter properties with a default value

### DIFF
--- a/packages/eslint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -396,6 +396,35 @@ ruleTester.run(
         errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
       },
       {
+        name: "constructor public property with a default value type is class that extends Resource (Bucket)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            constructor(public test: Bucket = undefined!) {
+              super();
+            }
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
+      {
         name: "public field type is array of class that extends Resource (Bucket[])",
         code: `
           class Construct {}

--- a/packages/eslint/src/__tests__/no-mutable-public-property-of-construct.test.ts
+++ b/packages/eslint/src/__tests__/no-mutable-public-property-of-construct.test.ts
@@ -80,6 +80,18 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           }
         `,
     },
+    // WHEN: constructor parameter property with a default value is readonly
+    {
+      code: `
+          class Construct {}
+          class DependencyClass extends Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public readonly test: DependencyClass = undefined!) {
+              super(scope, id);
+            }
+          }
+        `,
+    },
   ],
   invalid: [
     // WHEN: public field is mutable, nested superClass is Construct
@@ -219,6 +231,28 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           class Construct {}
           class TestClass extends Construct {
             constructor(scope: Construct, id: string, public readonly count) {
+              super(scope, id);
+            }
+          }
+        `,
+    },
+    // WHEN: constructor parameter property is mutable and has a default value
+    {
+      code: `
+          class Construct {}
+          class DependencyClass extends Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public test: DependencyClass = undefined!) {
+              super(scope, id);
+            }
+          }
+        `,
+      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      output: `
+          class Construct {}
+          class DependencyClass extends Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public readonly test: DependencyClass = undefined!) {
               super(scope, id);
             }
           }

--- a/packages/eslint/src/core/ast-node/finder/public-property.ts
+++ b/packages/eslint/src/core/ast-node/finder/public-property.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 
 import { findConstructor } from "./constructor";
+import { findConstructorParamIdentifier } from "./constructor-param-identifier";
 
 export type PublicProperty = {
   /**
@@ -43,16 +44,18 @@ const findPublicProperty = (
   switch (property.type) {
     // NOTE: get from constructor
     case AST_NODE_TYPES.TSParameterProperty: {
-      if (property.parameter.type !== AST_NODE_TYPES.Identifier) {
+      // NOTE: a default value wraps the binding in an AssignmentPattern, so unwrap it first
+      const identifier = findConstructorParamIdentifier(property);
+      if (!identifier) {
         return;
       }
       if (["private", "protected"].includes(property.accessibility ?? "")) {
         return;
       }
       return {
-        name: property.parameter.name,
+        name: identifier.name,
         node: property,
-        typeAnnotation: property.parameter.typeAnnotation,
+        typeAnnotation: identifier.typeAnnotation,
       };
     }
     // NOTE: get from class element

--- a/packages/oxlint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/packages/oxlint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -412,6 +412,35 @@ ruleTester.run(
         errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
       },
       {
+        name: "constructor public property with a default value type is class that extends Resource (Bucket)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            constructor(public test: Bucket = undefined!) {
+              super();
+            }
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
+      {
         name: "public field type is array of class that extends Resource (Bucket[])",
         code: `
           class Construct {}

--- a/packages/oxlint/src/__tests__/no-mutable-public-property-of-construct.test.ts
+++ b/packages/oxlint/src/__tests__/no-mutable-public-property-of-construct.test.ts
@@ -68,6 +68,17 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           }
         `,
     },
+    {
+      code: `
+          class Construct {}
+          class DependencyClass extends Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public readonly test: DependencyClass = undefined!) {
+              super(scope, id);
+            }
+          }
+        `,
+    },
   ],
   invalid: [
     {
@@ -199,6 +210,27 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           class Construct {}
           class TestClass extends Construct {
             constructor(scope: Construct, id: string, public readonly count) {
+              super(scope, id);
+            }
+          }
+        `,
+    },
+    {
+      code: `
+          class Construct {}
+          class DependencyClass extends Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public test: DependencyClass = undefined!) {
+              super(scope, id);
+            }
+          }
+        `,
+      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      output: `
+          class Construct {}
+          class DependencyClass extends Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public readonly test: DependencyClass = undefined!) {
               super(scope, id);
             }
           }

--- a/packages/oxlint/src/core/ast-node/finder/public-property.ts
+++ b/packages/oxlint/src/core/ast-node/finder/public-property.ts
@@ -3,6 +3,7 @@ import type { ESTree } from "corsa-oxlint";
 import { AST_NODE_TYPES } from "corsa-oxlint";
 
 import { findConstructor } from "./constructor";
+import { findConstructorParamIdentifier } from "./constructor-param-identifier";
 
 type Class = ESTree.ClassDeclaration | ESTree.ClassExpression;
 
@@ -42,12 +43,14 @@ const findPublicProperty = (property: ESTree.Node): PublicProperty | undefined =
   switch (property.type) {
     // NOTE: get from constructor
     case AST_NODE_TYPES.TSParameterProperty: {
-      if (property.parameter.type !== AST_NODE_TYPES.Identifier) return;
+      // NOTE: a default value wraps the binding in an AssignmentPattern, so unwrap it first
+      const identifier = findConstructorParamIdentifier(property);
+      if (!identifier) return;
       if (["private", "protected"].includes(property.accessibility ?? "")) return;
       return {
-        name: property.parameter.name,
+        name: identifier.name,
         node: property,
-        typeAnnotation: property.parameter.typeAnnotation,
+        typeAnnotation: identifier.typeAnnotation,
       };
     }
     case AST_NODE_TYPES.PropertyDefinition: {


### PR DESCRIPTION
### Issue # (if applicable)

Closes #564.

### Reason for this change

`findPublicPropertiesInClass` accepted a `TSParameterProperty` only when its `parameter` was a plain `Identifier`. A default value wraps the binding in an `AssignmentPattern`, so `public bucket: Bucket = <default>` was dropped by the finder and both rules built on it — `no-mutable-public-property-of-construct` and `no-construct-in-public-property-of-construct` — stopped seeing the property. This is the parameter-property form #560 normalized for the props rules; the public-property finder was left out of that scope.

### Description of changes

Reuse the existing `findConstructorParamIdentifier` finder (mirrored in both plugins) in `findPublicProperty` so the `TSParameterProperty` and `AssignmentPattern` layers are unwrapped consistently, and take the property name and type annotation from the unwrapped identifier. Accessibility handling and the `PropertyDefinition` path are unchanged, and the existing autofix anchor (the parameter node) already inserts `readonly ` in a legal position for the default-value form.

### Description of how you validated changes

- Added cases to both rules' suites in both plugins: the default-value parameter property is now reported by each rule, and the `readonly` variant stays valid for `no-mutable-public-property-of-construct`. The pre-existing plain parameter-property cases pin that the previous behavior is unchanged.
- Confirmed the four new invalid cases fail on `main` and pass with the fix.
- `vp check` and `vp test --run` (656/656) pass.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
