### PR TITLE
fix: report quoted property keys in no-construct-in-interface

### DIFF
--- a/packages/eslint/src/__tests__/no-construct-in-interface.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-in-interface.test.ts
@@ -137,6 +137,17 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       }
       `,
     },
+    {
+      name: "property key is a string literal and property type is interface (not construct class)",
+      code: `
+      interface IBucket {
+        bucketName: string;
+      }
+      interface MyConstructProps {
+        readonly "quotedBucket": IBucket;
+      }
+      `,
+    },
   ],
   invalid: [
     {
@@ -836,6 +847,62 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       }
       `,
       errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
+    {
+      name: "property key is a string literal and property type is class that extends Resource",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        readonly "quotedBucket": Bucket;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
+    {
+      name: "identifier key and string literal key are reported alike",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        readonly bucket: Bucket;
+        readonly "quotedBucket": Bucket;
+      }
+      `,
+      errors: [
+        { messageId: "invalidInterfaceProperty" },
+        { messageId: "invalidInterfaceProperty" },
+      ],
     },
   ],
 });

--- a/packages/eslint/src/core/ast-node/finder/static-property-key.ts
+++ b/packages/eslint/src/core/ast-node/finder/static-property-key.ts
@@ -1,0 +1,19 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+
+/**
+ * Find the statically known name of a property key
+ * @param key The key node of a property signature, property definition or property
+ * @returns The name for an Identifier key and the stringified value for a string or numeric
+ * Literal key, or null for keys that cannot be resolved statically (computed keys, template
+ * literals, etc.)
+ */
+export const findStaticPropertyName = (key: TSESTree.Node): string | null => {
+  if (key.type === AST_NODE_TYPES.Identifier) return key.name;
+  if (
+    key.type === AST_NODE_TYPES.Literal &&
+    (typeof key.value === "string" || typeof key.value === "number")
+  ) {
+    return String(key.value);
+  }
+  return null;
+};

--- a/packages/eslint/src/rules/no-construct-in-interface.ts
+++ b/packages/eslint/src/rules/no-construct-in-interface.ts
@@ -1,5 +1,6 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
+import { findStaticPropertyName } from "../core/ast-node/finder/static-property-key";
 import { findTypeOfCdkConstruct } from "../core/cdk-construct/type-finder";
 import { createRule } from "../shared/create-rule";
 
@@ -51,19 +52,3 @@ export const noConstructInInterface = createRule({
     };
   },
 });
-
-/**
- * Find the static name of a property key
- * @param key - The key of a property signature
- * @returns The property name, or null for keys that cannot be resolved statically
- */
-const findStaticPropertyName = (key: TSESTree.TSPropertySignature["key"]): string | null => {
-  if (key.type === AST_NODE_TYPES.Identifier) return key.name;
-  if (
-    key.type === AST_NODE_TYPES.Literal &&
-    (typeof key.value === "string" || typeof key.value === "number")
-  ) {
-    return String(key.value);
-  }
-  return null;
-};

--- a/packages/eslint/src/rules/no-construct-in-interface.ts
+++ b/packages/eslint/src/rules/no-construct-in-interface.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES, ESLintUtils, TSESTree } from "@typescript-eslint/utils";
 
 import { findTypeOfCdkConstruct } from "../core/cdk-construct/type-finder";
 import { createRule } from "../shared/create-rule";
@@ -27,12 +27,11 @@ export const noConstructInInterface = createRule({
     return {
       TSInterfaceDeclaration(node) {
         for (const property of node.body.body) {
-          if (
-            property.type !== AST_NODE_TYPES.TSPropertySignature ||
-            property.key.type !== AST_NODE_TYPES.Identifier
-          ) {
-            continue;
-          }
+          if (property.type !== AST_NODE_TYPES.TSPropertySignature) continue;
+
+          // NOTE: computed keys cannot be resolved statically, so they are skipped
+          const propertyName = findStaticPropertyName(property.key);
+          if (propertyName === null) continue;
 
           const type = parserServices.getTypeAtLocation(property);
           const result = findTypeOfCdkConstruct(type);
@@ -42,7 +41,7 @@ export const noConstructInInterface = createRule({
               node: property,
               messageId: "invalidInterfaceProperty",
               data: {
-                propertyName: property.key.name,
+                propertyName,
                 typeName: result.symbol.name,
               },
             });
@@ -52,3 +51,19 @@ export const noConstructInInterface = createRule({
     };
   },
 });
+
+/**
+ * Find the static name of a property key
+ * @param key - The key of a property signature
+ * @returns The property name, or null for keys that cannot be resolved statically
+ */
+const findStaticPropertyName = (key: TSESTree.TSPropertySignature["key"]): string | null => {
+  if (key.type === AST_NODE_TYPES.Identifier) return key.name;
+  if (
+    key.type === AST_NODE_TYPES.Literal &&
+    (typeof key.value === "string" || typeof key.value === "number")
+  ) {
+    return String(key.value);
+  }
+  return null;
+};

--- a/packages/eslint/src/rules/no-mutable-property-of-props-interface.ts
+++ b/packages/eslint/src/rules/no-mutable-property-of-props-interface.ts
@@ -1,5 +1,6 @@
-import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+import { AST_NODE_TYPES } from "@typescript-eslint/utils";
 
+import { findStaticPropertyName } from "../core/ast-node/finder/static-property-key";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -57,19 +58,3 @@ export const noMutablePropertyOfPropsInterface = createRule({
     };
   },
 });
-
-/**
- * Find the static name of a property key
- * @param key - The key of a property signature
- * @returns The property name, or null for keys that cannot be resolved statically
- */
-const findStaticPropertyName = (key: TSESTree.TSPropertySignature["key"]): string | null => {
-  if (key.type === AST_NODE_TYPES.Identifier) return key.name;
-  if (
-    key.type === AST_NODE_TYPES.Literal &&
-    (typeof key.value === "string" || typeof key.value === "number")
-  ) {
-    return String(key.value);
-  }
-  return null;
-};

--- a/packages/oxlint/src/__tests__/no-construct-in-interface.test.ts
+++ b/packages/oxlint/src/__tests__/no-construct-in-interface.test.ts
@@ -175,6 +175,17 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       }
       `,
     },
+    {
+      name: "property key is a string literal and property type is interface (not construct class)",
+      code: `
+      interface IBucket {
+        bucketName: string;
+      }
+      interface MyConstructProps {
+        readonly "quotedBucket": IBucket;
+      }
+      `,
+    },
   ],
   invalid: [
     {
@@ -874,6 +885,62 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       }
       `,
       errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
+    {
+      name: "property key is a string literal and property type is class that extends Resource",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        readonly "quotedBucket": Bucket;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
+    {
+      name: "identifier key and string literal key are reported alike",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        readonly bucket: Bucket;
+        readonly "quotedBucket": Bucket;
+      }
+      `,
+      errors: [
+        { messageId: "invalidInterfaceProperty" },
+        { messageId: "invalidInterfaceProperty" },
+      ],
     },
   ],
 });

--- a/packages/oxlint/src/core/ast-node/finder/static-property-key.ts
+++ b/packages/oxlint/src/core/ast-node/finder/static-property-key.ts
@@ -1,0 +1,21 @@
+import type { ESTree } from "corsa-oxlint";
+
+import { AST_NODE_TYPES } from "corsa-oxlint";
+
+/**
+ * Find the statically known name of a property key
+ * @param key The key node of a property signature, property definition or property
+ * @returns The name for an Identifier key and the stringified value for a string or numeric
+ * Literal key, or null for keys that cannot be resolved statically (computed keys, template
+ * literals, etc.)
+ */
+export const findStaticPropertyName = (key: ESTree.Node): string | null => {
+  if (key.type === AST_NODE_TYPES.Identifier) return key.name;
+  if (
+    key.type === AST_NODE_TYPES.Literal &&
+    (typeof key.value === "string" || typeof key.value === "number")
+  ) {
+    return String(key.value);
+  }
+  return null;
+};

--- a/packages/oxlint/src/rules/no-construct-in-interface.ts
+++ b/packages/oxlint/src/rules/no-construct-in-interface.ts
@@ -1,3 +1,5 @@
+import type { ESTree } from "corsa-oxlint";
+
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findTypeOfCdkConstruct } from "../core/cdk-construct/type-finder";
@@ -27,12 +29,11 @@ export const noConstructInInterface = createRule({
     return {
       TSInterfaceDeclaration(node) {
         for (const property of node.body.body) {
-          if (
-            property.type !== AST_NODE_TYPES.TSPropertySignature ||
-            property.key.type !== AST_NODE_TYPES.Identifier
-          ) {
-            continue;
-          }
+          if (property.type !== AST_NODE_TYPES.TSPropertySignature) continue;
+
+          // NOTE: computed keys cannot be resolved statically, so they are skipped
+          const propertyName = findStaticPropertyName(property.key);
+          if (propertyName === null) continue;
 
           const type = parserServices.getTypeAtLocation(property);
           const result = findTypeOfCdkConstruct(type, checker);
@@ -42,7 +43,7 @@ export const noConstructInInterface = createRule({
               node: property,
               messageId: "invalidInterfaceProperty",
               data: {
-                propertyName: property.key.name,
+                propertyName,
                 typeName: checker.getSymbolOfType(result)?.name ?? "",
               },
             });
@@ -52,3 +53,19 @@ export const noConstructInInterface = createRule({
     };
   },
 });
+
+/**
+ * Find the static name of a property key
+ * @param key - The key of a property signature
+ * @returns The property name, or null for keys that cannot be resolved statically
+ */
+const findStaticPropertyName = (key: ESTree.TSPropertySignature["key"]): string | null => {
+  if (key.type === AST_NODE_TYPES.Identifier) return key.name;
+  if (
+    key.type === AST_NODE_TYPES.Literal &&
+    (typeof key.value === "string" || typeof key.value === "number")
+  ) {
+    return String(key.value);
+  }
+  return null;
+};

--- a/packages/oxlint/src/rules/no-construct-in-interface.ts
+++ b/packages/oxlint/src/rules/no-construct-in-interface.ts
@@ -1,7 +1,6 @@
-import type { ESTree } from "corsa-oxlint";
-
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
+import { findStaticPropertyName } from "../core/ast-node/finder/static-property-key";
 import { findTypeOfCdkConstruct } from "../core/cdk-construct/type-finder";
 import { createRule } from "../shared/create-rule";
 
@@ -53,19 +52,3 @@ export const noConstructInInterface = createRule({
     };
   },
 });
-
-/**
- * Find the static name of a property key
- * @param key - The key of a property signature
- * @returns The property name, or null for keys that cannot be resolved statically
- */
-const findStaticPropertyName = (key: ESTree.TSPropertySignature["key"]): string | null => {
-  if (key.type === AST_NODE_TYPES.Identifier) return key.name;
-  if (
-    key.type === AST_NODE_TYPES.Literal &&
-    (typeof key.value === "string" || typeof key.value === "number")
-  ) {
-    return String(key.value);
-  }
-  return null;
-};

--- a/packages/oxlint/src/rules/no-mutable-property-of-props-interface.ts
+++ b/packages/oxlint/src/rules/no-mutable-property-of-props-interface.ts
@@ -1,7 +1,6 @@
-import type { ESTree } from "corsa-oxlint";
-
 import { AST_NODE_TYPES } from "corsa-oxlint";
 
+import { findStaticPropertyName } from "../core/ast-node/finder/static-property-key";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -57,19 +56,3 @@ export const noMutablePropertyOfPropsInterface = createRule({
     };
   },
 });
-
-/**
- * Find the static name of a property key
- * @param key - The key of a property signature
- * @returns The property name, or null for keys that cannot be resolved statically
- */
-const findStaticPropertyName = (key: ESTree.TSPropertySignature["key"]): string | null => {
-  if (key.type === AST_NODE_TYPES.Identifier) return key.name;
-  if (
-    key.type === AST_NODE_TYPES.Literal &&
-    (typeof key.value === "string" || typeof key.value === "number")
-  ) {
-    return String(key.value);
-  }
-  return null;
-};


### PR DESCRIPTION
### Issue # (if applicable)

Closes #563.

### Reason for this change

`no-construct-in-interface` skipped every interface property whose key is not a plain identifier, so quoted keys (`readonly "bucket": Bucket`) were never checked — inconsistent with the sibling props/interface rules, which were already fixed for quoted keys (#548, #551).

### Description of changes

- Widened the property-key guard in `no-construct-in-interface` from `Identifier`-only to statically resolvable keys (identifier + string/number literal). Applied to both packages.
- Added the key resolution as a shared finder, `core/ast-node/finder/static-property-key.ts`, in both packages instead of keeping it local to the rule. It takes any node so it also covers property definitions, not just property signatures.
- Switched `no-mutable-property-of-props-interface` over to the shared finder as well, removing the duplicate that already existed inline in that rule.
- Left the neighbouring `property-name.ts` finder alone: it resolves `ObjectPattern` property names, which is a different concept.
- Possible follow-up: `require-jsdoc` and `require-props-default-doc` still inline the same identifier/literal key resolution. Moving them onto the shared finder is intentionally out of scope here, since it changes rules this issue does not touch.

### Description of how you validated changes

- Added tests to both packages: quoted key with a Construct type (invalid), quoted key with an interface type (valid), and an identifier + quoted key pair reported identically (2 errors).
- Verified the 4 new invalid cases fail against the unpatched rule, then pass with the fix.
- `vp check` (245 files formatted, 142 files lint/type-checked, no errors) and `vp test --run` (688 tests, 34 files) pass at the repo root.
- `vp run -r pack && bash scripts/integration-test.sh` prints SUCCESS for all three runs (eslint:esm, eslint:cjs, oxlint), confirming the refactor keeps the expected error count over `examples/`.

Note: the PR for #572 (#582) also appends to the same test files; additions are placed at opposite ends of the arrays, so any merge conflict should be trivial.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
