### PR TITLE
fix: report re-exports and dynamic imports in no-import-private

### DIFF
--- a/packages/eslint/src/__tests__/no-import-private.test.ts
+++ b/packages/eslint/src/__tests__/no-import-private.test.ts
@@ -55,11 +55,59 @@ ruleTester.run("no-import-private", noImportPrivate, {
       code: 'import { shared } from "../shared";',
       filename: "src/lib/private/helper/x.ts",
     },
+    {
+      // WHEN: Re-exporting from a same level private directory is allowed
+      code: 'export { sample } from "./private/c.ts";',
+      filename: "src/sampleB/a.ts",
+    },
+    {
+      // WHEN: Re-exporting everything from a same level private directory is allowed
+      code: 'export * from "./private/c.ts";',
+      filename: "src/sampleB/a.ts",
+    },
+    {
+      // WHEN: Bare specifiers are not resolved as filesystem paths on re-exports either
+      code: 'export { x } from "@myorg/private-utils";',
+      filename: "src/moduleA/a.ts",
+    },
+    {
+      // WHEN: A local export declares no module source and pulls in nothing
+      code: "const sample = 1;\nexport { sample };",
+      filename: "src/sampleA/a.ts",
+    },
+    {
+      // WHEN: Dynamically importing from a same level private directory is allowed
+      code: 'export const load = () => import("./private/c.ts");',
+      filename: "src/sampleB/a.ts",
+    },
+    {
+      // WHEN: A dynamic import whose specifier is not a static string cannot be resolved
+      code: "export const load = (specifier) => import(specifier);",
+      filename: "src/sampleA/a.ts",
+    },
   ],
   invalid: [
     // WHEN: Importing modules in a private directory at a different level is not allowed
     {
       code: 'import { sample } from "../sampleB/private/c.ts";',
+      filename: "src/sampleA/a.ts",
+      errors: [{ messageId: "invalidImportPath" }],
+    },
+    // WHEN: Re-exporting from a private directory at a different level is not allowed
+    {
+      code: 'export { sample } from "../sampleB/private/c.ts";',
+      filename: "src/sampleA/a.ts",
+      errors: [{ messageId: "invalidImportPath" }],
+    },
+    // WHEN: Re-exporting everything from a private directory at a different level is not allowed
+    {
+      code: 'export * from "../sampleB/private/c.ts";',
+      filename: "src/sampleA/a.ts",
+      errors: [{ messageId: "invalidImportPath" }],
+    },
+    // WHEN: Dynamically importing from a private directory at a different level is not allowed
+    {
+      code: 'export const load = () => import("../sampleB/private/c.ts");',
       filename: "src/sampleA/a.ts",
       errors: [{ messageId: "invalidImportPath" }],
     },

--- a/packages/eslint/src/rules/no-import-private.ts
+++ b/packages/eslint/src/rules/no-import-private.ts
@@ -22,39 +22,67 @@ export const noImportPrivate: Rule.RuleModule = {
   create(context) {
     return {
       ImportDeclaration(node) {
-        const importPath = node.source.value?.toString() ?? "";
-        // Only relative imports can address a `private` directory on disk.
-        // Bare specifiers like `@scope/private-utils` must not be resolved as paths.
-        if (!importPath.startsWith("./") && !importPath.startsWith("../")) return;
-
-        const currentDirPath = path.dirname(context.filename);
-        const absoluteCurrentDirPath = path.resolve(currentDirPath);
-        const absoluteImportPath = path.resolve(currentDirPath, importPath);
-
-        const importSegments = getDirSegments(absoluteImportPath);
-        // Match the deepest exact `private` segment so that a `private` subtree
-        // can still import from its own child `private` directory.
-        const lastPrivateIndex = importSegments.lastIndexOf("private");
-        if (lastPrivateIndex === -1) return;
-
-        const importDirSegments = importSegments.slice(0, lastPrivateIndex);
-        const currentDirSegments = getDirSegments(absoluteCurrentDirPath);
-
-        // NOTE: an importer inside the private subtree itself is not crossing its boundary
-        const privateRootSegments = importSegments.slice(0, lastPrivateIndex + 1);
-        if (privateRootSegments.every((segment, index) => segment === currentDirSegments[index])) {
-          return;
-        }
-
-        if (
-          currentDirSegments.length !== importDirSegments.length ||
-          currentDirSegments.some((segment, index) => segment !== importDirSegments[index])
-        ) {
-          context.report({ node, messageId: "invalidImportPath" });
-        }
+        validateModuleSpecifier(node.source.value?.toString() ?? "", node, context);
+      },
+      ExportAllDeclaration(node) {
+        validateModuleSpecifier(node.source.value?.toString() ?? "", node, context);
+      },
+      ExportNamedDeclaration(node) {
+        // A local `export { x }` has no `source` and does not pull in another module.
+        if (!node.source) return;
+        validateModuleSpecifier(node.source.value?.toString() ?? "", node, context);
+      },
+      ImportExpression(node) {
+        // Only a statically known specifier can be resolved to a path.
+        const source = node.source;
+        if (source.type !== "Literal" || typeof source.value !== "string") return;
+        validateModuleSpecifier(source.value, node, context);
       },
     };
   },
+};
+
+/**
+ * Report the given node when its module specifier crosses into a `private`
+ * directory that belongs to another level of the hierarchy.
+ * @param specifier - The module specifier as written in the source
+ * @param node - The node to report the violation on
+ * @param context - The rule context provided by ESLint
+ */
+const validateModuleSpecifier = (
+  specifier: string,
+  node: Rule.Node,
+  context: Rule.RuleContext,
+): void => {
+  // Only relative specifiers can address a `private` directory on disk.
+  // Bare specifiers like `@scope/private-utils` must not be resolved as paths.
+  if (!specifier.startsWith("./") && !specifier.startsWith("../")) return;
+
+  const currentDirPath = path.dirname(context.filename);
+  const absoluteCurrentDirPath = path.resolve(currentDirPath);
+  const absoluteImportPath = path.resolve(currentDirPath, specifier);
+
+  const importSegments = getDirSegments(absoluteImportPath);
+  // Match the deepest exact `private` segment so that a `private` subtree
+  // can still import from its own child `private` directory.
+  const lastPrivateIndex = importSegments.lastIndexOf("private");
+  if (lastPrivateIndex === -1) return;
+
+  const importDirSegments = importSegments.slice(0, lastPrivateIndex);
+  const currentDirSegments = getDirSegments(absoluteCurrentDirPath);
+
+  // NOTE: an importer inside the private subtree itself is not crossing its boundary
+  const privateRootSegments = importSegments.slice(0, lastPrivateIndex + 1);
+  if (privateRootSegments.every((segment, index) => segment === currentDirSegments[index])) {
+    return;
+  }
+
+  if (
+    currentDirSegments.length !== importDirSegments.length ||
+    currentDirSegments.some((segment, index) => segment !== importDirSegments[index])
+  ) {
+    context.report({ node, messageId: "invalidImportPath" });
+  }
 };
 
 /**

--- a/packages/oxlint/src/__tests__/no-import-private.test.ts
+++ b/packages/oxlint/src/__tests__/no-import-private.test.ts
@@ -55,11 +55,59 @@ ruleTester.run("no-import-private", noImportPrivate, {
       code: 'import { shared } from "../shared";',
       filename: "src/lib/private/helper/x.ts",
     },
+    {
+      // WHEN: Re-exporting from a same level private directory is allowed
+      code: 'export { sample } from "./private/c.ts";',
+      filename: "src/sampleB/a.ts",
+    },
+    {
+      // WHEN: Re-exporting everything from a same level private directory is allowed
+      code: 'export * from "./private/c.ts";',
+      filename: "src/sampleB/a.ts",
+    },
+    {
+      // WHEN: Bare specifiers are not resolved as filesystem paths on re-exports either
+      code: 'export { x } from "@myorg/private-utils";',
+      filename: "src/moduleA/a.ts",
+    },
+    {
+      // WHEN: A local export declares no module source and pulls in nothing
+      code: "const sample = 1;\nexport { sample };",
+      filename: "src/sampleA/a.ts",
+    },
+    {
+      // WHEN: Dynamically importing from a same level private directory is allowed
+      code: 'export const load = () => import("./private/c.ts");',
+      filename: "src/sampleB/a.ts",
+    },
+    {
+      // WHEN: A dynamic import whose specifier is not a static string cannot be resolved
+      code: "export const load = (specifier) => import(specifier);",
+      filename: "src/sampleA/a.ts",
+    },
   ],
   invalid: [
     // WHEN: Importing modules in a private directory at a different level is not allowed
     {
       code: 'import { sample } from "../sampleB/private/c.ts";',
+      filename: "src/sampleA/a.ts",
+      errors: [{ messageId: "invalidImportPath" }],
+    },
+    // WHEN: Re-exporting from a private directory at a different level is not allowed
+    {
+      code: 'export { sample } from "../sampleB/private/c.ts";',
+      filename: "src/sampleA/a.ts",
+      errors: [{ messageId: "invalidImportPath" }],
+    },
+    // WHEN: Re-exporting everything from a private directory at a different level is not allowed
+    {
+      code: 'export * from "../sampleB/private/c.ts";',
+      filename: "src/sampleA/a.ts",
+      errors: [{ messageId: "invalidImportPath" }],
+    },
+    // WHEN: Dynamically importing from a private directory at a different level is not allowed
+    {
+      code: 'export const load = () => import("../sampleB/private/c.ts");',
       filename: "src/sampleA/a.ts",
       errors: [{ messageId: "invalidImportPath" }],
     },

--- a/packages/oxlint/src/rules/no-import-private.ts
+++ b/packages/oxlint/src/rules/no-import-private.ts
@@ -1,3 +1,5 @@
+import type { ESTree, RuleContext } from "corsa-oxlint";
+
 import * as path from "path";
 
 import { createRule } from "../shared/create-rule";
@@ -22,40 +24,65 @@ export const noImportPrivate = createRule({
   create(context) {
     return {
       ImportDeclaration(node) {
-        const importPath = node.source.value?.toString() ?? "";
-        // Only relative imports can address a `private` directory on disk.
-        // Bare specifiers like `@scope/private-utils` must not be resolved as paths.
-        if (!importPath.startsWith("./") && !importPath.startsWith("../")) return;
-
-        const currentDirPath = path.dirname(context.filename);
-        const absoluteCurrentDirPath = path.resolve(currentDirPath);
-        const absoluteImportPath = path.resolve(currentDirPath, importPath);
-
-        const importSegments = getDirSegments(absoluteImportPath);
-        // Match the deepest exact `private` segment so that a `private` subtree
-        // can still import from its own child `private` directory.
-        const lastPrivateIndex = importSegments.lastIndexOf("private");
-        if (lastPrivateIndex === -1) return;
-
-        const importDirSegments = importSegments.slice(0, lastPrivateIndex);
-        const currentDirSegments = getDirSegments(absoluteCurrentDirPath);
-
-        // NOTE: an importer inside the private subtree itself is not crossing its boundary
-        const privateRootSegments = importSegments.slice(0, lastPrivateIndex + 1);
-        if (privateRootSegments.every((segment, index) => segment === currentDirSegments[index])) {
-          return;
-        }
-
-        if (
-          currentDirSegments.length !== importDirSegments.length ||
-          currentDirSegments.some((segment, index) => segment !== importDirSegments[index])
-        ) {
-          context.report({ node, messageId: "invalidImportPath" });
-        }
+        validateModuleSpecifier(node.source.value?.toString() ?? "", node, context);
+      },
+      ExportAllDeclaration(node) {
+        validateModuleSpecifier(node.source.value?.toString() ?? "", node, context);
+      },
+      ExportNamedDeclaration(node) {
+        // A local `export { x }` has no `source` and does not pull in another module.
+        if (!node.source) return;
+        validateModuleSpecifier(node.source.value?.toString() ?? "", node, context);
+      },
+      ImportExpression(node) {
+        // Only a statically known specifier can be resolved to a path.
+        const source = node.source;
+        if (source.type !== "Literal" || typeof source.value !== "string") return;
+        validateModuleSpecifier(source.value, node, context);
       },
     };
   },
 });
+
+/**
+ * Report the given node when its module specifier crosses into a `private`
+ * directory that belongs to another level of the hierarchy.
+ */
+const validateModuleSpecifier = (
+  specifier: string,
+  node: ESTree.Node,
+  context: RuleContext,
+): void => {
+  // Only relative specifiers can address a `private` directory on disk.
+  // Bare specifiers like `@scope/private-utils` must not be resolved as paths.
+  if (!specifier.startsWith("./") && !specifier.startsWith("../")) return;
+
+  const currentDirPath = path.dirname(context.filename);
+  const absoluteCurrentDirPath = path.resolve(currentDirPath);
+  const absoluteImportPath = path.resolve(currentDirPath, specifier);
+
+  const importSegments = getDirSegments(absoluteImportPath);
+  // Match the deepest exact `private` segment so that a `private` subtree
+  // can still import from its own child `private` directory.
+  const lastPrivateIndex = importSegments.lastIndexOf("private");
+  if (lastPrivateIndex === -1) return;
+
+  const importDirSegments = importSegments.slice(0, lastPrivateIndex);
+  const currentDirSegments = getDirSegments(absoluteCurrentDirPath);
+
+  // NOTE: an importer inside the private subtree itself is not crossing its boundary
+  const privateRootSegments = importSegments.slice(0, lastPrivateIndex + 1);
+  if (privateRootSegments.every((segment, index) => segment === currentDirSegments[index])) {
+    return;
+  }
+
+  if (
+    currentDirSegments.length !== importDirSegments.length ||
+    currentDirSegments.some((segment, index) => segment !== importDirSegments[index])
+  ) {
+    context.report({ node, messageId: "invalidImportPath" });
+  }
+};
 
 /**
  * Split the directory path into segments using the platform separator.


### PR DESCRIPTION
### Issue # (if applicable)

Closes #566.

### Reason for this change

`no-import-private` registered only an `ImportDeclaration` visitor, so `export { x } from "..."`, `export * from "..."` and dynamic `import("...")` crossed a `private` directory boundary without any diagnostic. The re-export forms are the more serious case, since they additionally re-publish the private module through the current module's public surface.

### Description of changes

Extract the specifier-based path check into a shared `validateModuleSpecifier` helper (mirrored in both plugins) and route four visitors through it: `ImportDeclaration`, `ExportAllDeclaration`, `ExportNamedDeclaration` — only when it carries a `source`, so a local `export { x }` is untouched — and `ImportExpression`, only when its specifier is a static string literal, since a computed specifier cannot be resolved to a path. The path matching semantics introduced in #550 are unchanged.

### Description of how you validated changes

- Added 9 cases per plugin: cross-hierarchy `export { x } from`, `export *` and dynamic `import()` are now reported, while same-level re-export / dynamic import, bare-specifier re-export, local `export { x }` with no source, and a non-literal dynamic specifier stay valid.
- Reverting only the two rule files makes exactly the three new invalid cases fail in both packages, confirming they pin the fix.
- `vp check` and `vp test --run` (668/668) pass.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
