### PR TITLE
fix: check public parameter properties in require-jsdoc

### DIFF
--- a/packages/eslint/src/__tests__/require-jsdoc.test.ts
+++ b/packages/eslint/src/__tests__/require-jsdoc.test.ts
@@ -60,6 +60,59 @@ ruleTester.run("require-jsdoc", requireJSDoc, {
         }
       `,
     },
+    {
+      // WHEN: public parameter property with a JSDoc comment
+      code: `
+        class Construct {}
+        class TestConstruct extends Construct {
+          constructor(
+            scope: Construct,
+            id: string,
+            /**
+             * Description for bucket
+             */
+            public readonly bucket: string,
+          ) {
+            super();
+          }
+        }
+      `,
+    },
+    {
+      // WHEN: parameter property is not public
+      code: `
+        class Construct {}
+        class TestConstruct extends Construct {
+          constructor(
+            scope: Construct,
+            id: string,
+            private readonly bucket: string,
+            protected readonly table: string,
+          ) {
+            super();
+          }
+        }
+      `,
+    },
+    {
+      // WHEN: constructor parameter is not a parameter property
+      code: `
+        class Construct {}
+        class TestConstruct extends Construct {
+          constructor(scope: Construct, id: string, bucket: string) {
+            super();
+          }
+        }
+      `,
+    },
+    {
+      // WHEN: parameter property of a non-Construct class
+      code: `
+        class SampleConstruct {
+          constructor(public readonly bucket: string) {}
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -143,6 +196,53 @@ ruleTester.run("require-jsdoc", requireJSDoc, {
         {
           messageId: "missingJSDoc",
           data: { propertyName: "bucket-name" },
+        },
+      ],
+    },
+    {
+      // WHEN: public parameter property without JSDoc comments
+      code: `
+        class Construct {}
+        class TestConstruct extends Construct {
+          constructor(
+            scope: Construct,
+            id: string,
+            public readonly bucket: string,
+            readonly table: string,
+          ) {
+            super();
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "missingJSDoc",
+          data: { propertyName: "bucket" },
+        },
+        {
+          messageId: "missingJSDoc",
+          data: { propertyName: "table" },
+        },
+      ],
+    },
+    {
+      // WHEN: public parameter property with a default value and without JSDoc comments
+      code: `
+        class Construct {}
+        class TestConstruct extends Construct {
+          constructor(
+            scope: Construct,
+            id: string,
+            public readonly bucket: string = "sample",
+          ) {
+            super();
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "missingJSDoc",
+          data: { propertyName: "bucket" },
         },
       ],
     },

--- a/packages/eslint/src/rules/require-jsdoc.ts
+++ b/packages/eslint/src/rules/require-jsdoc.ts
@@ -1,6 +1,8 @@
 import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 import { findAttachedJSDocComments } from "../core/ast-node/finder/attached-jsdoc-comment";
+import { findConstructorParamIdentifier } from "../core/ast-node/finder/constructor-param-identifier";
+import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
@@ -86,6 +88,30 @@ export const requireJSDoc = createRule({
           node,
           messageId: "missingJSDoc",
           data: { propertyName },
+        });
+      },
+      TSParameterProperty(node) {
+        // NOTE: TypeScript declares an instance field from a parameter property,
+        // so it is a public property of the class just like a PropertyDefinition
+        if (["private", "protected"].includes(node.accessibility ?? "")) return;
+
+        const identifier = findConstructorParamIdentifier(node);
+        if (!identifier) return;
+
+        // NOTE: Check if the class extends Construct
+        const classDeclaration = findEnclosingClass(node);
+        if (!classDeclaration?.superClass) return;
+
+        const classType = parserServices.getTypeAtLocation(classDeclaration);
+        if (!isConstructType(classType)) return;
+
+        const comments = findAttachedJSDocComments(context.sourceCode, node);
+        if (comments.length > 0) return;
+
+        context.report({
+          node,
+          messageId: "missingJSDoc",
+          data: { propertyName: identifier.name },
         });
       },
     };

--- a/packages/oxlint/src/__tests__/require-jsdoc.test.ts
+++ b/packages/oxlint/src/__tests__/require-jsdoc.test.ts
@@ -54,6 +54,59 @@ ruleTester.run("require-jsdoc", requireJSDoc, {
         }
       `,
     },
+    {
+      // WHEN: public parameter property with a JSDoc comment
+      code: `
+        class Construct {}
+        class TestConstruct extends Construct {
+          constructor(
+            scope: Construct,
+            id: string,
+            /**
+             * Description for bucket
+             */
+            public readonly bucket: string,
+          ) {
+            super();
+          }
+        }
+      `,
+    },
+    {
+      // WHEN: parameter property is not public
+      code: `
+        class Construct {}
+        class TestConstruct extends Construct {
+          constructor(
+            scope: Construct,
+            id: string,
+            private readonly bucket: string,
+            protected readonly table: string,
+          ) {
+            super();
+          }
+        }
+      `,
+    },
+    {
+      // WHEN: constructor parameter is not a parameter property
+      code: `
+        class Construct {}
+        class TestConstruct extends Construct {
+          constructor(scope: Construct, id: string, bucket: string) {
+            super();
+          }
+        }
+      `,
+    },
+    {
+      // WHEN: parameter property of a non-Construct class
+      code: `
+        class SampleConstruct {
+          constructor(public readonly bucket: string) {}
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -137,6 +190,53 @@ ruleTester.run("require-jsdoc", requireJSDoc, {
         {
           messageId: "missingJSDoc",
           data: { propertyName: "bucket-name" },
+        },
+      ],
+    },
+    {
+      // WHEN: public parameter property without JSDoc comments
+      code: `
+        class Construct {}
+        class TestConstruct extends Construct {
+          constructor(
+            scope: Construct,
+            id: string,
+            public readonly bucket: string,
+            readonly table: string,
+          ) {
+            super();
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "missingJSDoc",
+          data: { propertyName: "bucket" },
+        },
+        {
+          messageId: "missingJSDoc",
+          data: { propertyName: "table" },
+        },
+      ],
+    },
+    {
+      // WHEN: public parameter property with a default value and without JSDoc comments
+      code: `
+        class Construct {}
+        class TestConstruct extends Construct {
+          constructor(
+            scope: Construct,
+            id: string,
+            public readonly bucket: string = "sample",
+          ) {
+            super();
+          }
+        }
+      `,
+      errors: [
+        {
+          messageId: "missingJSDoc",
+          data: { propertyName: "bucket" },
         },
       ],
     },

--- a/packages/oxlint/src/rules/require-jsdoc.ts
+++ b/packages/oxlint/src/rules/require-jsdoc.ts
@@ -1,6 +1,8 @@
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findAttachedJSDocComments } from "../core/ast-node/finder/attached-jsdoc-comment";
+import { findConstructorParamIdentifier } from "../core/ast-node/finder/constructor-param-identifier";
+import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
@@ -87,6 +89,30 @@ export const requireJSDoc = createRule({
           node,
           messageId: "missingJSDoc",
           data: { propertyName },
+        });
+      },
+      TSParameterProperty(node) {
+        // NOTE: TypeScript declares an instance field from a parameter property,
+        // so it is a public property of the class just like a PropertyDefinition
+        if (["private", "protected"].includes(node.accessibility ?? "")) return;
+
+        const identifier = findConstructorParamIdentifier(node);
+        if (!identifier) return;
+
+        // NOTE: Check if the class extends Construct
+        const classDeclaration = findEnclosingClass(node);
+        if (!classDeclaration?.superClass) return;
+
+        const classType = parserServices.getTypeAtLocation(classDeclaration);
+        if (!isConstructType(classType, checker)) return;
+
+        const comments = findAttachedJSDocComments(context.sourceCode, node);
+        if (comments.length > 0) return;
+
+        context.report({
+          node,
+          messageId: "missingJSDoc",
+          data: { propertyName: identifier.name },
         });
       },
     };


### PR DESCRIPTION
### Issue # (if applicable)

Closes #565.

### Reason for this change

The rule is documented as covering Construct public properties, and every other public-property rule treats a constructor parameter property as one — TypeScript declares the instance field from it. `require-jsdoc` implemented its own visitors for `TSPropertySignature` and `PropertyDefinition` only, so declaring a property as a parameter property silently exempted it from the rule.

### Description of changes

Add a `TSParameterProperty` visitor (mirrored in both plugins) that resolves the enclosing class via the existing `findEnclosingClass` finder, applies the same "class extends Construct" check as the `PropertyDefinition` path, and reports the parameter property when no JSDoc block is attached. Accessibility is treated as in the other public-property rules: `private` / `protected` are exempt, an accessibility-less `readonly` parameter property is public. The binding is unwrapped with the existing `findConstructorParamIdentifier` finder, so the default-value form is covered as well — this is self-contained and does not depend on #564, which fixes the same gap in the shared public-property finder used by the other rules.

`findAttachedJSDocComments` needed no change: a JSDoc block on its own line inside the constructor parens is attributed correctly, since the previous token is the preceding `(` or `,` on an earlier line.

### Description of how you validated changes

- Added cases to both plugins' suites: undocumented public parameter properties (explicit `public` and accessibility-less `readonly`) are reported, the default-value form is reported, a documented one is valid, and `private` / `protected` parameter properties, plain constructor parameters, parameter properties of non-Construct classes, and the pre-existing class-field cases stay valid.
- Confirmed the four new invalid cases fail without the visitor and pass with it.
- `vp check` and `vp test --run` (662/662) pass.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
