### PR TITLE
fix: skip pascal-case-construct-id autofix when the converted id is already taken

### DIFF
--- a/packages/eslint/src/__tests__/pascal-case-construct-id.test.ts
+++ b/packages/eslint/src/__tests__/pascal-case-construct-id.test.ts
@@ -230,5 +230,124 @@ ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
       errors: [{ messageId: "invalidConstructId" }],
       output: null,
     },
+    // WHEN: the converted id is already used by another construct in the same constructor
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "Logs");
+          new TestClass(props, "logs");
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    // WHEN: several case variants of one word are used in the same constructor
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "myBucket");
+          new TestClass(props, "my_bucket");
+          new TestClass(props, "my-bucket");
+          new TestClass(props, "my bucket");
+          new TestClass(props, "my.bucket");
+        }
+      }`,
+      errors: [
+        { messageId: "invalidConstructId" },
+        { messageId: "invalidConstructId" },
+        { messageId: "invalidConstructId" },
+        { messageId: "invalidConstructId" },
+        { messageId: "invalidConstructId" },
+      ],
+      output: null,
+    },
+    // WHEN: the constructor holds no other construct id to collide with
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "my-bucket");
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "MyBucket");
+        }
+      }`,
+    },
+    // WHEN: ids converting to the same value live in different constructors
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class FirstConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "my-bucket");
+        }
+      }
+      class SecondConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "my_bucket");
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }, { messageId: "invalidConstructId" }],
+      output: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class FirstConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "MyBucket");
+        }
+      }
+      class SecondConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "MyBucket");
+        }
+      }`,
+    },
   ],
 });

--- a/packages/eslint/src/core/ast-node/finder/sibling-construct-id-strings.ts
+++ b/packages/eslint/src/core/ast-node/finder/sibling-construct-id-strings.ts
@@ -9,6 +9,17 @@ const FUNCTION_TYPES = [
   AST_NODE_TYPES.ArrowFunctionExpression,
 ] as const;
 
+/**
+ * Collect the static construct IDs (string literals and expression-less template
+ * literals) of the other constructs created in the same body as a given node.
+ *
+ * NOTE: The enclosing function body approximates the construct scope. The first
+ * argument, which carries the real scope, is not tracked.
+ */
+export const findSiblingConstructIdStrings = (node: TSESTree.NewExpression): string[] => {
+  return collectConstructIdStrings(findScopeRoot(node), node);
+};
+
 const isFunctionNode = (node: TSESTree.Node): boolean => {
   return FUNCTION_TYPES.some((type) => type === node.type);
 };
@@ -47,15 +58,4 @@ const collectConstructIdStrings = (
   })();
 
   return ownId === null ? descendantIds : [ownId, ...descendantIds];
-};
-
-/**
- * Collect the static construct IDs (string literals and expression-less template
- * literals) of the other constructs created in the same body as a given node.
- *
- * NOTE: The enclosing function body approximates the construct scope. The first
- * argument, which carries the real scope, is not tracked.
- */
-export const findSiblingConstructIdStrings = (node: TSESTree.NewExpression): string[] => {
-  return collectConstructIdStrings(findScopeRoot(node), node);
 };

--- a/packages/eslint/src/core/ast-node/finder/sibling-construct-id-strings.ts
+++ b/packages/eslint/src/core/ast-node/finder/sibling-construct-id-strings.ts
@@ -1,0 +1,61 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+
+import { findChildNodes } from "./child-nodes";
+import { findConstructIdString } from "./construct-id-string";
+
+const FUNCTION_TYPES = [
+  AST_NODE_TYPES.FunctionExpression,
+  AST_NODE_TYPES.FunctionDeclaration,
+  AST_NODE_TYPES.ArrowFunctionExpression,
+] as const;
+
+const isFunctionNode = (node: TSESTree.Node): boolean => {
+  return FUNCTION_TYPES.some((type) => type === node.type);
+};
+
+/**
+ * Find the node that delimits the constructs created next to a given node:
+ * the nearest enclosing function body, or the whole program when the node is
+ * written at the top level of the file.
+ */
+const findScopeRoot = (node: TSESTree.Node): TSESTree.Node => {
+  const parent = node.parent;
+  if (!parent) return node;
+  if (isFunctionNode(parent)) return parent;
+  return findScopeRoot(parent);
+};
+
+/**
+ * Collect the static ID of every `NewExpression` below a node, skipping the
+ * target itself and never descending into a nested function body because those
+ * constructs belong to another scope root.
+ */
+const collectConstructIdStrings = (
+  node: TSESTree.Node,
+  target: TSESTree.NewExpression,
+): string[] => {
+  const descendantIds = findChildNodes(node).flatMap((child) => {
+    if (isFunctionNode(child)) return [];
+    return collectConstructIdStrings(child, target);
+  });
+
+  const ownId = (() => {
+    if (node === target) return null;
+    if (node.type !== AST_NODE_TYPES.NewExpression || node.arguments.length < 2) return null;
+    // NOTE: Treat the second argument as ID
+    return findConstructIdString(node.arguments[1]);
+  })();
+
+  return ownId === null ? descendantIds : [ownId, ...descendantIds];
+};
+
+/**
+ * Collect the static construct IDs (string literals and expression-less template
+ * literals) of the other constructs created in the same body as a given node.
+ *
+ * NOTE: The enclosing function body approximates the construct scope. The first
+ * argument, which carries the real scope, is not tracked.
+ */
+export const findSiblingConstructIdStrings = (node: TSESTree.NewExpression): string[] => {
+  return collectConstructIdStrings(findScopeRoot(node), node);
+};

--- a/packages/eslint/src/rules/pascal-case-construct-id.ts
+++ b/packages/eslint/src/rules/pascal-case-construct-id.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
 
 import { findConstructIdString } from "../core/ast-node/finder/construct-id-string";
+import { findSiblingConstructIdStrings } from "../core/ast-node/finder/sibling-construct-id-strings";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
@@ -76,6 +77,20 @@ const findQuoteType = (node: TSESTree.Node): QuoteType => {
 };
 
 /**
+ * Check whether another construct created in the same body already owns the
+ * converted ID. `toPascalCase` is lossy ("Logs" and "logs" both become "Logs"),
+ * so fixing such an ID would create a duplicate construct ID that throws at
+ * synth time.
+ */
+const isTakenByAnotherConstruct = (node: TSESTree.NewExpression, pascalCaseValue: string) => {
+  // NOTE: Compare against the raw sibling IDs and their converted forms, so that
+  // several case variants of one word are not all fixed onto the same ID either.
+  return findSiblingConstructIdStrings(node).some(
+    (siblingId) => siblingId === pascalCaseValue || toPascalCase(siblingId) === pascalCaseValue,
+  );
+};
+
+/**
  * Check the construct ID is PascalCase
  */
 const validateConstructId = (node: TSESTree.NewExpression, context: Context) => {
@@ -90,8 +105,9 @@ const validateConstructId = (node: TSESTree.NewExpression, context: Context) => 
 
   const pascalCaseValue = toPascalCase(constructId);
   // Skip the fix when the converted value would still fail validation
-  // (e.g. leading digits, symbol-only input) so the fix always converges.
-  if (!isPascalCase(pascalCaseValue)) {
+  // (e.g. leading digits, symbol-only input) so the fix always converges,
+  // or when it would collide with another construct ID in the same body.
+  if (!isPascalCase(pascalCaseValue) || isTakenByAnotherConstruct(node, pascalCaseValue)) {
     context.report({ node: secondArg, messageId: "invalidConstructId" });
     return;
   }

--- a/packages/oxlint/src/__tests__/pascal-case-construct-id.test.ts
+++ b/packages/oxlint/src/__tests__/pascal-case-construct-id.test.ts
@@ -188,5 +188,120 @@ ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
       errors: [{ messageId: "invalidConstructId" }],
       output: null,
     },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "Logs");
+          new TestClass(props, "logs");
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "myBucket");
+          new TestClass(props, "my_bucket");
+          new TestClass(props, "my-bucket");
+          new TestClass(props, "my bucket");
+          new TestClass(props, "my.bucket");
+        }
+      }`,
+      errors: [
+        { messageId: "invalidConstructId" },
+        { messageId: "invalidConstructId" },
+        { messageId: "invalidConstructId" },
+        { messageId: "invalidConstructId" },
+        { messageId: "invalidConstructId" },
+      ],
+      output: null,
+    },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "my-bucket");
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "MyBucket");
+        }
+      }`,
+    },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class FirstConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "my-bucket");
+        }
+      }
+      class SecondConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "my_bucket");
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }, { messageId: "invalidConstructId" }],
+      output: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class FirstConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "MyBucket");
+        }
+      }
+      class SecondConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "MyBucket");
+        }
+      }`,
+    },
   ],
 });

--- a/packages/oxlint/src/core/ast-node/finder/sibling-construct-id-strings.ts
+++ b/packages/oxlint/src/core/ast-node/finder/sibling-construct-id-strings.ts
@@ -11,6 +11,17 @@ const FUNCTION_TYPES = [
   AST_NODE_TYPES.ArrowFunctionExpression,
 ] as const;
 
+/**
+ * Collect the static construct IDs (string literals and expression-less template
+ * literals) of the other constructs created in the same body as a given node.
+ *
+ * NOTE: The enclosing function body approximates the construct scope. The first
+ * argument, which carries the real scope, is not tracked.
+ */
+export const findSiblingConstructIdStrings = (node: ESTree.NewExpression): string[] => {
+  return collectConstructIdStrings(findScopeRoot(node), node);
+};
+
 const isFunctionNode = (node: ESTree.Node): boolean => {
   // NOTE: Corsa's wide node union does not narrow via Array.includes,
   // so use .some with equality to keep type inference happy.
@@ -48,15 +59,4 @@ const collectConstructIdStrings = (node: ESTree.Node, target: ESTree.NewExpressi
   })();
 
   return ownId === null ? descendantIds : [ownId, ...descendantIds];
-};
-
-/**
- * Collect the static construct IDs (string literals and expression-less template
- * literals) of the other constructs created in the same body as a given node.
- *
- * NOTE: The enclosing function body approximates the construct scope. The first
- * argument, which carries the real scope, is not tracked.
- */
-export const findSiblingConstructIdStrings = (node: ESTree.NewExpression): string[] => {
-  return collectConstructIdStrings(findScopeRoot(node), node);
 };

--- a/packages/oxlint/src/core/ast-node/finder/sibling-construct-id-strings.ts
+++ b/packages/oxlint/src/core/ast-node/finder/sibling-construct-id-strings.ts
@@ -1,0 +1,62 @@
+import type { ESTree } from "corsa-oxlint";
+
+import { AST_NODE_TYPES } from "corsa-oxlint";
+
+import { findChildNodes } from "./child-nodes";
+import { findConstructIdString } from "./construct-id-string";
+
+const FUNCTION_TYPES = [
+  AST_NODE_TYPES.FunctionExpression,
+  AST_NODE_TYPES.FunctionDeclaration,
+  AST_NODE_TYPES.ArrowFunctionExpression,
+] as const;
+
+const isFunctionNode = (node: ESTree.Node): boolean => {
+  // NOTE: Corsa's wide node union does not narrow via Array.includes,
+  // so use .some with equality to keep type inference happy.
+  return FUNCTION_TYPES.some((type) => type === node.type);
+};
+
+/**
+ * Find the node that delimits the constructs created next to a given node:
+ * the nearest enclosing function body, or the whole program when the node is
+ * written at the top level of the file.
+ */
+const findScopeRoot = (node: ESTree.Node): ESTree.Node => {
+  const parent = node.parent;
+  if (!parent) return node;
+  if (isFunctionNode(parent)) return parent;
+  return findScopeRoot(parent);
+};
+
+/**
+ * Collect the static ID of every `NewExpression` below a node, skipping the
+ * target itself and never descending into a nested function body because those
+ * constructs belong to another scope root.
+ */
+const collectConstructIdStrings = (node: ESTree.Node, target: ESTree.NewExpression): string[] => {
+  const descendantIds = findChildNodes(node).flatMap((child) => {
+    if (isFunctionNode(child)) return [];
+    return collectConstructIdStrings(child, target);
+  });
+
+  const ownId = (() => {
+    if (node === target) return null;
+    if (node.type !== AST_NODE_TYPES.NewExpression || node.arguments.length < 2) return null;
+    // NOTE: Treat the second argument as ID
+    return findConstructIdString(node.arguments[1]);
+  })();
+
+  return ownId === null ? descendantIds : [ownId, ...descendantIds];
+};
+
+/**
+ * Collect the static construct IDs (string literals and expression-less template
+ * literals) of the other constructs created in the same body as a given node.
+ *
+ * NOTE: The enclosing function body approximates the construct scope. The first
+ * argument, which carries the real scope, is not tracked.
+ */
+export const findSiblingConstructIdStrings = (node: ESTree.NewExpression): string[] => {
+  return collectConstructIdStrings(findScopeRoot(node), node);
+};

--- a/packages/oxlint/src/rules/pascal-case-construct-id.ts
+++ b/packages/oxlint/src/rules/pascal-case-construct-id.ts
@@ -3,6 +3,7 @@ import type { ESTree, RuleContext } from "corsa-oxlint";
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findConstructIdString } from "../core/ast-node/finder/construct-id-string";
+import { findSiblingConstructIdStrings } from "../core/ast-node/finder/sibling-construct-id-strings";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
@@ -72,6 +73,20 @@ const findQuoteType = (node: ESTree.Node): QuoteType => {
 };
 
 /**
+ * Check whether another construct created in the same body already owns the
+ * converted ID. `toPascalCase` is lossy ("Logs" and "logs" both become "Logs"),
+ * so fixing such an ID would create a duplicate construct ID that throws at
+ * synth time.
+ */
+const isTakenByAnotherConstruct = (node: ESTree.NewExpression, pascalCaseValue: string) => {
+  // NOTE: Compare against the raw sibling IDs and their converted forms, so that
+  // several case variants of one word are not all fixed onto the same ID either.
+  return findSiblingConstructIdStrings(node).some(
+    (siblingId) => siblingId === pascalCaseValue || toPascalCase(siblingId) === pascalCaseValue,
+  );
+};
+
+/**
  * Check the construct ID is PascalCase
  */
 const validateConstructId = (node: ESTree.NewExpression, context: RuleContext) => {
@@ -86,8 +101,9 @@ const validateConstructId = (node: ESTree.NewExpression, context: RuleContext) =
 
   const pascalCaseValue = toPascalCase(constructId);
   // Skip the fix when the converted value would still fail validation
-  // (e.g. leading digits, symbol-only input) so the fix always converges.
-  if (!isPascalCase(pascalCaseValue)) {
+  // (e.g. leading digits, symbol-only input) so the fix always converges,
+  // or when it would collide with another construct ID in the same body.
+  if (!isPascalCase(pascalCaseValue) || isTakenByAnotherConstruct(node, pascalCaseValue)) {
     context.report({ node: secondArg, messageId: "invalidConstructId" });
     return;
   }


### PR DESCRIPTION
### Issue # (if applicable)

Closes #573.

### Reason for this change

`toPascalCase` is lossy — `"Logs"` and `"logs"` both convert to `"Logs"` — and the `pascal-case-construct-id` fixer replaced the ID with the converted value without checking whether another construct in the same scope already used it. `--fix` therefore rewrote working code into code that throws `There is already a Construct with name 'Logs'` at construction/synth time, and the next lint run was clean, so nothing signalled the breakage.

### Description of changes

- Report the violation without a fix when the converted ID would duplicate another construct ID created in the same body, extending the converge-or-abstain behaviour introduced in #559.
- Add a finder (mirrored in both plugins) that collects the static IDs of the other constructs created in the same body. The collision check compares against both those raw IDs and their own converted forms, so several case variants of one word are not all fixed onto the same ID either.

Design decision: the collision check is scoped to the nearest enclosing function body — constructor, method or plain function, and the whole program for top-level code — and does not follow the first argument, which carries the real construct scope. Constructs created in one body normally share a scope, so this is a deliberate approximation: it can withhold a fix that would in fact have been safe, but it never applies a fix that introduces a duplicate ID inside that body.

### Description of how you validated changes

- Added invalid cases to both plugins' suites: `"Logs"` and `"logs"` in one constructor reports the lowercase one with no fix (`output: null`); the five variants from the issue (`"myBucket"`, `"my_bucket"`, `"my-bucket"`, `"my bucket"`, `"my.bucket"`) are all reported with no fix; a lone `"my-bucket"` is still fixed to `"MyBucket"`; and IDs converting to the same value in two different constructors are still both fixed.
- Confirmed the new cases fail without the guard, then `vp check` and `vp test --run` (658/658) pass at the repo root.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
