### PR TITLE
fix: resolve public property types from the declaration identifier

### DIFF
--- a/packages/eslint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -243,6 +243,87 @@ ruleTester.run(
         errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
       },
       {
+        name: "public field with a definite assignment assertion type is class that extends Resource (Bucket)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            public readonly test!: Bucket;
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
+      {
+        name: "public optional field type is class that extends Resource (Bucket)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            public readonly test?: Bucket;
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
+      {
+        name: "public field with an initializer type is class that extends Resource (Bucket)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            public readonly test: Bucket = undefined!;
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
+      {
         name: "public field type is class that extends Resource (BucketBase)",
         code: `
           class Construct {}

--- a/packages/eslint/src/rules/no-construct-in-public-property-of-construct.ts
+++ b/packages/eslint/src/rules/no-construct-in-public-property-of-construct.ts
@@ -1,4 +1,5 @@
 import {
+  AST_NODE_TYPES,
   ESLintUtils,
   ParserServicesWithTypeInformation,
   TSESLint,
@@ -61,7 +62,14 @@ const validatePublicProperty = (
   // Inferring the type from an initializer is out of scope for this rule.
   if (!publicProperty.typeAnnotation) return;
 
-  const type = parserServices.getTypeAtLocation(publicProperty.node);
+  // NOTE: The declared type is read from the declaration's identifier rather than from the
+  // property node, because the identifier resolves consistently for every declaration form
+  // (`!`, `?`, initializer) in both type checkers.
+  const typeNode =
+    publicProperty.node.type === AST_NODE_TYPES.PropertyDefinition
+      ? publicProperty.node.key
+      : publicProperty.node;
+  const type = parserServices.getTypeAtLocation(typeNode);
   const constructType = findTypeOfCdkConstruct(type);
   if (constructType) {
     context.report({

--- a/packages/oxlint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/packages/oxlint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -259,6 +259,87 @@ ruleTester.run(
         errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
       },
       {
+        name: "public field with a definite assignment assertion type is class that extends Resource (Bucket)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            public readonly test!: Bucket;
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
+      {
+        name: "public optional field type is class that extends Resource (Bucket)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            public readonly test?: Bucket;
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
+      {
+        name: "public field with an initializer type is class that extends Resource (Bucket)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            public readonly test: Bucket = undefined!;
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
+      {
         name: "public field type is class that extends Resource (BucketBase)",
         code: `
           class Construct {}

--- a/packages/oxlint/src/rules/no-construct-in-public-property-of-construct.ts
+++ b/packages/oxlint/src/rules/no-construct-in-public-property-of-construct.ts
@@ -1,6 +1,6 @@
 import type { ParserServices, RuleContext } from "corsa-oxlint";
 
-import { ESLintUtils } from "corsa-oxlint";
+import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import {
   findPublicPropertiesInClass,
@@ -53,7 +53,14 @@ const validatePublicProperty = (
   // Inferring the type from an initializer is out of scope for this rule.
   if (!publicProperty.typeAnnotation) return;
 
-  const type = parserServices.getTypeAtLocation(publicProperty.node);
+  // NOTE: The declared type is read from the declaration's identifier rather than from the
+  // property node, because the identifier resolves consistently for every declaration form
+  // (`!`, `?`, initializer) in both type checkers.
+  const typeNode =
+    publicProperty.node.type === AST_NODE_TYPES.PropertyDefinition
+      ? publicProperty.node.key
+      : publicProperty.node;
+  const type = parserServices.getTypeAtLocation(typeNode);
   const checker = parserServices.program.getTypeChecker();
   const constructType = findTypeOfCdkConstruct(type, checker);
   if (constructType) {


### PR DESCRIPTION
### Issue # (if applicable)

Closes #571.

### Reason for this change

The oxlint plugin read the property type with `getTypeAtLocation(publicProperty.node)`, i.e. from the `PropertyDefinition`. In corsa-oxlint that lookup returns a symbol-less, property-less type as soon as the property carries a definite assignment assertion (`!`) or an optional marker (`?`), so the Construct type was never recognised and the property was silently skipped. Only the initializer form was reported, while eslint-plugin-awscdk reported all three — the two plugins disagreed on identical input.

### Description of changes

Both packages now read the declared type from the declaration's identifier (the `PropertyDefinition` key) rather than from the property node. This is the rule's canonical design in both packages: the identifier resolves consistently for every declaration form (`!`, `?`, initializer) under both type checkers, so the two packages stay mirrored and the implementation is independent of the underlying corsa behavior.

The resolution is a two-line inline expression in `validatePublicProperty`, textually identical in both rule files apart from the package-specific imports and types — no new helper and no new module dependency. The "must have an explicit type annotation" precondition and the reported node are unchanged, and the eslint package's behavior is unchanged (its existing cases, including the three parity fixtures, pass before and after).

Parameter-property handling is untouched: that branch resolves the property node exactly as before, so the change is orthogonal to #592 and holds whichever way that lands. `core/ast-node/finder/public-property.ts` is deliberately not modified.

Resolving the *type annotation* node instead was evaluated and rejected — it is correct only for bare type references. Probing corsa-oxlint 1.12.4 (the pinned version) with `checker.typeToString` on this rule's own fixtures, comparing all three candidate nodes:

```
                                       annotation node   property node            key node
TSArrayType        (Bucket[])          any               Bucket[]                 Bucket[]
TSTupleType        ([Bucket, Bucket])  any               [Bucket, Bucket]         [Bucket, Bucket]
TSIntersectionType (Bucket & {...})    any               Bucket & { ... }         Bucket & { ... }
TSTypeReference    (Readonly<Bucket>)  Readonly<T>       Readonly<Bucket>         Readonly<Bucket>
TSTypeReference    (Record<string,..>) Record<K, T>      Record<string, Bucket>   Record<string, Bucket>
TSTypeReference    (Bucket, via `!`)   Bucket            any                      Bucket
TSTypeReference    (Bucket, via `?`)   Bucket            any                      Bucket | undefined
```

The annotation node yields `any` for array / tuple / intersection types and the *uninstantiated* generic for type references, which regressed 19 existing cases (`Bucket[]`, `Array<Bucket>`, `Record<string, Bucket>`, `Promise<Array<Bucket>>`, tuples, unions, intersections, and the `Readonly` / `Partial` / `Required` / `NonNullable` / custom-wrapper cases). The property node is the form this issue reports — it yields `any` for the `!` and `?` declarations. The key node is the only one that resolves correctly in every row.

### Description of how you validated changes

- Added invalid cases for the `!`, `?` and initializer forms to the oxlint suite; the `!` and `?` cases reproduce the miss before the change and pass after it, and the pre-existing plain-declaration, container-type and parameter-property cases stay green.
- Added the same three cases to the eslint suite to pin the cross-plugin parity the issue is about; they pass both before and after the eslint-side change, confirming it is behavior-neutral there.
- `vp check` and `vp test --run` (702/702) pass on corsa-oxlint 1.12.4 / oxlint 1.80.0 (the versions pinned after #589).
- `vp run -r pack && bash scripts/integration-test.sh` → 3× `SUCCESS: Expected error count found!` (43 errors, eslint esm + eslint cjs + oxlint).
- Rebased onto `main` (`37afa3b`); only the two test files can conflict with #592.

### Related upstream issues

- ubugeeei-prod/corsa-bind#473 — `getTypeAtLocation` returns `any` for `PropertyDefinition` nodes declared with `!` or `?`. Informational: the underlying corsa behavior is tracked upstream, but this rule no longer depends on it, since resolving from the declaration identifier is the design in both packages.
- ubugeeei-prod/corsa-bind#474 — `getTypeAtLocation` on annotation type nodes returns `any` / uninstantiated generics. This is why the annotation-node approach was rejected (see the probe table above).

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_

