### PR TITLE
fix: report Function / Topic / Queue / DatabaseCluster in no-construct-in-interface and no-construct-in-public-property-of-construct

### DIFF
--- a/packages/eslint/src/__tests__/no-construct-in-interface.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-in-interface.test.ts
@@ -15,6 +15,29 @@ const ruleTester = new RuleTester({
 ruleTester.run("no-construct-in-interface", noConstructInInterface, {
   valid: [
     {
+      name: "property type is class whose declaration-merged base class has no matching interface",
+      code: `
+      class Resource {}
+      export abstract class BaseLoadBalancer extends Resource {
+        constructor() {
+          super();
+        }
+      }
+      // NOTE: declaration merging leaves the base class without a matching read-only interface
+      export interface BaseLoadBalancer {
+        addListener(): void;
+      }
+      export class ApplicationLoadBalancer extends BaseLoadBalancer {
+        constructor() {
+          super();
+        }
+      }
+      interface MyConstructProps {
+        loadBalancer: ApplicationLoadBalancer;
+      }
+      `,
+    },
+    {
       name: "property type is not class (string)",
       code: `
       interface TestInterface {
@@ -139,6 +162,36 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
     },
   ],
   invalid: [
+    {
+      name: "property type is class whose declaration-merged base class implements a matching interface (Topic extends TopicBase)",
+      code: `
+      class Resource {}
+      interface ITopic {
+        topicArn: string;
+      }
+      export abstract class TopicBase extends Resource implements ITopic {
+        abstract readonly topicArn: string;
+        constructor() {
+          super();
+        }
+      }
+      // NOTE: reproduces the generated CDK augmentation that merges an interface into the base class
+      export interface TopicBase {
+        addSubscription(): void;
+      }
+      export class Topic extends TopicBase {
+        readonly topicArn: string;
+        constructor() {
+          super();
+          this.topicArn = "test-topic";
+        }
+      }
+      interface MyConstructProps {
+        topic: Topic;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
     {
       name: "property type is class that extends Resource (Bucket extends BucketBase)",
       code: `

--- a/packages/eslint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -18,6 +18,30 @@ ruleTester.run(
   {
     valid: [
       {
+        name: "public field type is class whose declaration-merged base class has no matching interface",
+        code: `
+          class Construct {}
+          class Resource {}
+          export abstract class BaseLoadBalancer extends Resource {
+            constructor() {
+              super();
+            }
+          }
+          // NOTE: declaration merging leaves the base class without a matching read-only interface
+          export interface BaseLoadBalancer {
+            addListener(): void;
+          }
+          export class ApplicationLoadBalancer extends BaseLoadBalancer {
+            constructor() {
+              super();
+            }
+          }
+          class TestClass extends Construct {
+            public loadBalancer: ApplicationLoadBalancer;
+          }
+        `,
+      },
+      {
         name: "field type is not class (string)",
         code: `
           class Construct {}
@@ -188,6 +212,37 @@ ruleTester.run(
       },
     ],
     invalid: [
+      {
+        name: "public field type is class whose declaration-merged base class implements a matching interface (Topic extends TopicBase)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface ITopic {
+            topicArn: string;
+          }
+          export abstract class TopicBase extends Resource implements ITopic {
+            abstract readonly topicArn: string;
+            constructor() {
+              super();
+            }
+          }
+          // NOTE: reproduces the generated CDK augmentation that merges an interface into the base class
+          export interface TopicBase {
+            addSubscription(): void;
+          }
+          export class Topic extends TopicBase {
+            readonly topicArn: string;
+            constructor() {
+              super();
+              this.topicArn = "test-topic";
+            }
+          }
+          class TestClass extends Construct {
+            public topic: Topic;
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
       {
         name: "public field type is Record with Construct as value type (Record<string, Bucket>)",
         code: `

--- a/packages/eslint/src/core/ts-type/checker/is-class.ts
+++ b/packages/eslint/src/core/ts-type/checker/is-class.ts
@@ -2,6 +2,14 @@ import { SymbolFlags, Type } from "typescript";
 
 import { getSymbol } from "./private/get-symbol";
 
+/**
+ * Checks whether the type is declared by a class
+ *
+ * NOTE: `SymbolFlags` is a bit field, so it must be tested with a mask.
+ * A class that is declaration-merged with an interface of the same name
+ * (as the generated CDK `*-augmentations.generated.d.ts` files do) carries
+ * `Interface` and `Transient` in addition to `Class`.
+ */
 export const isClassType = (type: Type): boolean => {
-  return getSymbol(type)?.flags === SymbolFlags.Class;
+  return ((getSymbol(type)?.flags ?? 0) & SymbolFlags.Class) !== 0;
 };

--- a/packages/oxlint/src/__tests__/no-construct-in-interface.test.ts
+++ b/packages/oxlint/src/__tests__/no-construct-in-interface.test.ts
@@ -9,6 +9,29 @@ const ruleTester = new RuleTester({
 ruleTester.run("no-construct-in-interface", noConstructInInterface, {
   valid: [
     {
+      name: "property type is class whose declaration-merged base class has no matching interface",
+      code: `
+      class Resource {}
+      export abstract class BaseLoadBalancer extends Resource {
+        constructor() {
+          super();
+        }
+      }
+      // NOTE: declaration merging leaves the base class without a matching read-only interface
+      export interface BaseLoadBalancer {
+        addListener(): void;
+      }
+      export class ApplicationLoadBalancer extends BaseLoadBalancer {
+        constructor() {
+          super();
+        }
+      }
+      interface MyConstructProps {
+        loadBalancer: ApplicationLoadBalancer;
+      }
+      `,
+    },
+    {
       name: "property type is not class (string)",
       code: `
       interface TestInterface {
@@ -177,6 +200,36 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
     },
   ],
   invalid: [
+    {
+      name: "property type is class whose declaration-merged base class implements a matching interface (Topic extends TopicBase)",
+      code: `
+      class Resource {}
+      interface ITopic {
+        topicArn: string;
+      }
+      export abstract class TopicBase extends Resource implements ITopic {
+        abstract readonly topicArn: string;
+        constructor() {
+          super();
+        }
+      }
+      // NOTE: reproduces the generated CDK augmentation that merges an interface into the base class
+      export interface TopicBase {
+        addSubscription(): void;
+      }
+      export class Topic extends TopicBase {
+        readonly topicArn: string;
+        constructor() {
+          super();
+          this.topicArn = "test-topic";
+        }
+      }
+      interface MyConstructProps {
+        topic: Topic;
+      }
+      `,
+      errors: [{ messageId: "invalidInterfaceProperty" }],
+    },
     {
       name: "property type is class that extends Resource (Bucket extends BucketBase)",
       code: `

--- a/packages/oxlint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/packages/oxlint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -12,6 +12,30 @@ ruleTester.run(
   {
     valid: [
       {
+        name: "public field type is class whose declaration-merged base class has no matching interface",
+        code: `
+          class Construct {}
+          class Resource {}
+          export abstract class BaseLoadBalancer extends Resource {
+            constructor() {
+              super();
+            }
+          }
+          // NOTE: declaration merging leaves the base class without a matching read-only interface
+          export interface BaseLoadBalancer {
+            addListener(): void;
+          }
+          export class ApplicationLoadBalancer extends BaseLoadBalancer {
+            constructor() {
+              super();
+            }
+          }
+          class TestClass extends Construct {
+            public loadBalancer: ApplicationLoadBalancer;
+          }
+        `,
+      },
+      {
         name: "field type is not class (string)",
         code: `
           class Construct {}
@@ -204,6 +228,37 @@ ruleTester.run(
       },
     ],
     invalid: [
+      {
+        name: "public field type is class whose declaration-merged base class implements a matching interface (Topic extends TopicBase)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface ITopic {
+            topicArn: string;
+          }
+          export abstract class TopicBase extends Resource implements ITopic {
+            abstract readonly topicArn: string;
+            constructor() {
+              super();
+            }
+          }
+          // NOTE: reproduces the generated CDK augmentation that merges an interface into the base class
+          export interface TopicBase {
+            addSubscription(): void;
+          }
+          export class Topic extends TopicBase {
+            readonly topicArn: string;
+            constructor() {
+              super();
+              this.topicArn = "test-topic";
+            }
+          }
+          class TestClass extends Construct {
+            public topic: Topic;
+          }
+        `,
+        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
+      },
       {
         name: "public field type is Record with Construct as value type (Record<string, Bucket>)",
         code: `


### PR DESCRIPTION
### Issue # (if applicable)

Closes #572.

### Reason for this change

The eslint plugin missed `Function` / `Topic` / `Queue` / `DatabaseCluster` in `no-construct-in-interface` and `no-construct-in-public-property-of-construct` because `isClassType` compared `symbol.flags === SymbolFlags.Class` with strict equality: CDK base classes that are declaration-merged by the generated `*-augmentations.generated.d.ts` files carry `Transient | Interface | Class` flags, so the base-chain walk stopped and the oxlint plugin diverged.

### Description of changes

- Changed the `SymbolFlags` test in `packages/eslint/src/core/ts-type/checker/is-class.ts` to a bitmask (`(flags & SymbolFlags.Class) !== 0`), with a doc comment explaining why the bit field needs a mask. eslint package only — the oxlint plugin has no equivalent gate and already behaves correctly.
- Added fixtures to both rules in both packages using a locally declaration-merged base class (class + same-name interface, `DatabaseCluster`-shaped), so the regression does not depend on aws-cdk-lib versions; plus a valid case (merged base without a matching read-only interface) locking that the widened predicate does not over-report. The oxlint fixtures pin cross-plugin parity (they pass unchanged).

### Description of how you validated changes

- Reproduced the divergence first: the 2 new eslint invalid cases fail on the unpatched code while the identical oxlint cases pass.
- `vp check` and `vp test --run` (658 tests, 34 files) pass at the repo root.

Note: the PR for #563 (#577) also appends to the `no-construct-in-interface` test files; additions are placed at opposite ends of the arrays, so any merge conflict should be trivial.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
