### PR TITLE
fix: skip prevent-construct-id-collision when the scope is created per iteration

### DIFF
--- a/packages/eslint/src/__tests__/prevent-construct-id-collision.test.ts
+++ b/packages/eslint/src/__tests__/prevent-construct-id-collision.test.ts
@@ -258,6 +258,58 @@ ruleTester.run("prevent-construct-id-collision", preventConstructIdCollision, {
       }
       `,
     },
+    // WHEN: Construct scope is created inside a for...of loop
+    {
+      name: "literal ID with a scope created inside for...of is valid",
+      code: `
+      class Construct {}
+      class Stack extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          for (const stage of ["dev", "prod"]) {
+            const stack = new Stack(this, \`\${stage}Stack\`);
+            new Bucket(stack, "Bucket");
+          }
+        }
+      }
+      `,
+    },
+    // WHEN: Construct scope is created inside a forEach callback
+    {
+      name: "literal ID with a scope created inside forEach is valid",
+      code: `
+      class Construct {}
+      class Stack extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          ["dev", "prod"].forEach((stage) => {
+            const stack = new Stack(this, \`\${stage}Stack\`);
+            new Bucket(stack, "Bucket");
+          });
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     // WHEN: Literal ID inside forEach
@@ -520,6 +572,33 @@ ruleTester.run("prevent-construct-id-collision", preventConstructIdCollision, {
           super(scope, id);
           for (let i = 0; i < 3; i++) {
             [1, 2, 3].forEach(() => new Bucket(this, "Bucket"));
+          }
+        }
+      }
+      `,
+      errors: [{ messageId: "preventConstructIdCollision", data: { constructId: "Bucket" } }],
+    },
+    // WHEN: Literal ID with a scope declared outside the loop
+    {
+      name: "literal ID with a scope declared outside the loop is invalid",
+      code: `
+      class Construct {}
+      class Stack extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const stack = new Stack(this, "Stack");
+          for (const stage of ["dev", "prod"]) {
+            new Bucket(stack, "Bucket");
           }
         }
       }

--- a/packages/eslint/src/__tests__/prevent-construct-id-collision.test.ts
+++ b/packages/eslint/src/__tests__/prevent-construct-id-collision.test.ts
@@ -605,5 +605,88 @@ ruleTester.run("prevent-construct-id-collision", preventConstructIdCollision, {
       `,
       errors: [{ messageId: "preventConstructIdCollision", data: { constructId: "Bucket" } }],
     },
+    // WHEN: Literal ID with the loop binding as scope
+    {
+      name: "literal ID with the loop binding as scope is invalid",
+      code: `
+      class Construct {}
+      class Stack extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const stacks = [new Stack(this, "StackA"), new Stack(this, "StackB")];
+          for (const stack of stacks) {
+            new Bucket(stack, "Bucket");
+          }
+        }
+      }
+      `,
+      errors: [{ messageId: "preventConstructIdCollision", data: { constructId: "Bucket" } }],
+    },
+    // WHEN: Literal ID with an iteration callback parameter as scope
+    {
+      name: "literal ID with an iteration callback parameter as scope is invalid",
+      code: `
+      class Construct {}
+      class Stack extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const stacks = [new Stack(this, "StackA"), new Stack(this, "StackB")];
+          stacks.forEach((stack) => {
+            new Bucket(stack, "Bucket");
+          });
+        }
+      }
+      `,
+      errors: [{ messageId: "preventConstructIdCollision", data: { constructId: "Bucket" } }],
+    },
+    // WHEN: Literal ID in an inner loop with a scope declared in the outer loop
+    {
+      name: "literal ID with a scope declared in the outer loop is invalid",
+      code: `
+      class Construct {}
+      class Stack extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          for (const stage of ["dev", "prod"]) {
+            const stack = new Stack(this, \`\${stage}Stack\`);
+            for (const name of ["a", "b"]) {
+              new Bucket(stack, "Bucket");
+            }
+          }
+        }
+      }
+      `,
+      errors: [{ messageId: "preventConstructIdCollision", data: { constructId: "Bucket" } }],
+    },
   ],
 });

--- a/packages/eslint/src/core/ast-node/finder/declared-in-enclosing-blocks.ts
+++ b/packages/eslint/src/core/ast-node/finder/declared-in-enclosing-blocks.ts
@@ -3,19 +3,19 @@ import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 /**
  * Check whether a variable of a given name is declared by a VariableDeclaration in one of
  * the block statements enclosing a node, searching up to a given ancestor (inclusive).
- * @param name The variable name to look for
  * @param node The node to start searching from
+ * @param name The variable name to look for
  * @param ancestor The node at which the search stops
  * @returns true if an enclosing block declares the variable
  */
 export const isDeclaredInEnclosingBlocks = (
-  name: string,
   node: TSESTree.Node,
+  name: string,
   ancestor: TSESTree.Node,
 ): boolean => {
   if (declaresVariableName(node, name)) return true;
   if (node === ancestor || !node.parent) return false;
-  return isDeclaredInEnclosingBlocks(name, node.parent, ancestor);
+  return isDeclaredInEnclosingBlocks(node.parent, name, ancestor);
 };
 
 /**

--- a/packages/eslint/src/core/ast-node/finder/declared-in-enclosing-blocks.ts
+++ b/packages/eslint/src/core/ast-node/finder/declared-in-enclosing-blocks.ts
@@ -1,0 +1,35 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+
+/**
+ * Check whether a variable of a given name is declared by a VariableDeclaration in one of
+ * the block statements enclosing a node, searching up to a given ancestor (inclusive).
+ * @param name The variable name to look for
+ * @param node The node to start searching from
+ * @param ancestor The node at which the search stops
+ * @returns true if an enclosing block declares the variable
+ */
+export const isDeclaredInEnclosingBlocks = (
+  name: string,
+  node: TSESTree.Node,
+  ancestor: TSESTree.Node,
+): boolean => {
+  if (declaresVariableName(node, name)) return true;
+  if (node === ancestor || !node.parent) return false;
+  return isDeclaredInEnclosingBlocks(name, node.parent, ancestor);
+};
+
+/**
+ * Check whether a block statement declares a variable with the given name
+ */
+const declaresVariableName = (node: TSESTree.Node, name: string): boolean => {
+  if (node.type !== AST_NODE_TYPES.BlockStatement) return false;
+
+  return node.body.some(
+    (statement) =>
+      statement.type === AST_NODE_TYPES.VariableDeclaration &&
+      statement.declarations.some(
+        (declarator) =>
+          declarator.id.type === AST_NODE_TYPES.Identifier && declarator.id.name === name,
+      ),
+  );
+};

--- a/packages/eslint/src/core/ast-node/finder/enclosing-loop-body.ts
+++ b/packages/eslint/src/core/ast-node/finder/enclosing-loop-body.ts
@@ -1,0 +1,72 @@
+import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
+
+const ITERATION_METHODS = new Set([
+  "forEach",
+  "map",
+  "flatMap",
+  "filter",
+  "reduce",
+  "reduceRight",
+  "every",
+  "some",
+  "find",
+  "findIndex",
+  "findLast",
+  "findLastIndex",
+]);
+
+/**
+ * Find the body of the loop enclosing a given node.
+ * Detects for, for...in, for...of, while, do...while statements,
+ * and callbacks of iteration methods (forEach, map, etc.)
+ * @param node The node to start searching from
+ * @returns The enclosing loop body or null if the node is not inside a loop
+ */
+export const findEnclosingLoopBody = (node: TSESTree.Node): TSESTree.Node | null => {
+  const parent = node.parent;
+  if (!parent) return null;
+
+  // NOTE: Detect loop statements
+  if (
+    parent.type === AST_NODE_TYPES.ForStatement ||
+    parent.type === AST_NODE_TYPES.ForInStatement ||
+    parent.type === AST_NODE_TYPES.ForOfStatement ||
+    parent.type === AST_NODE_TYPES.WhileStatement ||
+    parent.type === AST_NODE_TYPES.DoWhileStatement
+  ) {
+    return parent.body;
+  }
+
+  // NOTE: Detect iteration method callbacks (ArrowFunction/FunctionExpression)
+  if (
+    (parent.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+      parent.type === AST_NODE_TYPES.FunctionExpression) &&
+    isIterationMethodCallback(parent)
+  ) {
+    return parent.body;
+  }
+
+  // NOTE: Stop at non-constructor method definitions
+  if (parent.type === AST_NODE_TYPES.MethodDefinition && parent.kind !== "constructor") {
+    return null;
+  }
+
+  return findEnclosingLoopBody(parent);
+};
+
+/**
+ * Check whether an arrow function or function expression is a callback of an iteration method
+ */
+const isIterationMethodCallback = (
+  node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
+): boolean => {
+  const parent = node.parent;
+  if (parent?.type !== AST_NODE_TYPES.CallExpression) return false;
+
+  const callee = parent.callee;
+  if (callee.type !== AST_NODE_TYPES.MemberExpression) return false;
+
+  if (callee.property.type !== AST_NODE_TYPES.Identifier) return false;
+
+  return ITERATION_METHODS.has(callee.property.name);
+};

--- a/packages/eslint/src/rules/prevent-construct-id-collision.ts
+++ b/packages/eslint/src/rules/prevent-construct-id-collision.ts
@@ -49,7 +49,12 @@ const validateConstructIdInLoop = (
   node: TSESTree.NewExpression,
   context: Parameters<typeof preventConstructIdCollision.create>[0],
 ) => {
-  if (!isInsideLoop(node)) return;
+  const loopBody = findEnclosingLoopBody(node);
+  if (!loopBody) return;
+
+  // NOTE: A scope declared inside the loop body is re-created on every iteration,
+  //       so a literal ID cannot collide within it
+  if (isScopeDeclaredInLoopBody(node.arguments[0], loopBody)) return;
 
   const secondArg = node.arguments[1];
 
@@ -76,41 +81,84 @@ const validateConstructIdInLoop = (
 };
 
 /**
- * Check whether a node is inside a loop.
+ * Find the body of the loop that encloses a node.
  * Detects for, for...in, for...of, while, do...while statements,
  * and callbacks of iteration methods (forEach, map, etc.)
+ * Returns null when the node is not inside a loop.
  */
-const isInsideLoop = (node: TSESTree.Node): boolean => {
-  let current = node.parent;
-  while (current) {
-    // NOTE: Detect loop statements
-    if (
-      current.type === AST_NODE_TYPES.ForStatement ||
-      current.type === AST_NODE_TYPES.ForInStatement ||
-      current.type === AST_NODE_TYPES.ForOfStatement ||
-      current.type === AST_NODE_TYPES.WhileStatement ||
-      current.type === AST_NODE_TYPES.DoWhileStatement
-    ) {
-      return true;
-    }
+const findEnclosingLoopBody = (node: TSESTree.Node): TSESTree.Node | null => {
+  const parent = node.parent;
+  if (!parent) return null;
 
-    // NOTE: Detect iteration method callbacks (ArrowFunction/FunctionExpression)
-    if (
-      (current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-        current.type === AST_NODE_TYPES.FunctionExpression) &&
-      isIterationMethodCallback(current)
-    ) {
-      return true;
-    }
-
-    // NOTE: Stop at non-constructor method definitions
-    if (current.type === AST_NODE_TYPES.MethodDefinition && current.kind !== "constructor") {
-      return false;
-    }
-
-    current = current.parent;
+  // NOTE: Detect loop statements
+  if (
+    parent.type === AST_NODE_TYPES.ForStatement ||
+    parent.type === AST_NODE_TYPES.ForInStatement ||
+    parent.type === AST_NODE_TYPES.ForOfStatement ||
+    parent.type === AST_NODE_TYPES.WhileStatement ||
+    parent.type === AST_NODE_TYPES.DoWhileStatement
+  ) {
+    return parent.body;
   }
-  return false;
+
+  // NOTE: Detect iteration method callbacks (ArrowFunction/FunctionExpression)
+  if (
+    (parent.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+      parent.type === AST_NODE_TYPES.FunctionExpression) &&
+    isIterationMethodCallback(parent)
+  ) {
+    return parent.body;
+  }
+
+  // NOTE: Stop at non-constructor method definitions
+  if (parent.type === AST_NODE_TYPES.MethodDefinition && parent.kind !== "constructor") {
+    return null;
+  }
+
+  return findEnclosingLoopBody(parent);
+};
+
+/**
+ * Check whether the scope argument is an identifier declared inside the loop body.
+ * Only a variable declaration is treated as a per-iteration scope: any other form
+ * (`this`, an outer variable, a member expression, ...) may be shared across iterations.
+ */
+const isScopeDeclaredInLoopBody = (
+  scopeArg: TSESTree.NewExpression["arguments"][number],
+  loopBody: TSESTree.Node,
+): boolean => {
+  if (scopeArg.type !== AST_NODE_TYPES.Identifier) return false;
+  return isDeclaredInEnclosingBlocks(scopeArg.name, scopeArg, loopBody);
+};
+
+/**
+ * Check whether a block enclosing the node, up to and including the loop body,
+ * declares a variable with the given name
+ */
+const isDeclaredInEnclosingBlocks = (
+  name: string,
+  node: TSESTree.Node,
+  loopBody: TSESTree.Node,
+): boolean => {
+  if (declaresVariableName(node, name)) return true;
+  if (node === loopBody || !node.parent) return false;
+  return isDeclaredInEnclosingBlocks(name, node.parent, loopBody);
+};
+
+/**
+ * Check whether a block statement declares a variable with the given name
+ */
+const declaresVariableName = (node: TSESTree.Node, name: string): boolean => {
+  if (node.type !== AST_NODE_TYPES.BlockStatement) return false;
+
+  return node.body.some(
+    (statement) =>
+      statement.type === AST_NODE_TYPES.VariableDeclaration &&
+      statement.declarations.some(
+        (declarator) =>
+          declarator.id.type === AST_NODE_TYPES.Identifier && declarator.id.name === name,
+      ),
+  );
 };
 
 const ITERATION_METHODS = new Set([

--- a/packages/eslint/src/rules/prevent-construct-id-collision.ts
+++ b/packages/eslint/src/rules/prevent-construct-id-collision.ts
@@ -55,7 +55,7 @@ const validateConstructIdInLoop = (
   if (!loopBody) return;
 
   // NOTE: A scope declared inside the loop body is re-created on every iteration,
-  //       so a literal ID cannot collide within it
+  // so a literal ID cannot collide within it
   if (isScopeDeclaredInLoopBody(node.arguments[0], loopBody)) return;
 
   const secondArg = node.arguments[1];
@@ -92,5 +92,5 @@ const isScopeDeclaredInLoopBody = (
   loopBody: TSESTree.Node,
 ): boolean => {
   if (scopeArg.type !== AST_NODE_TYPES.Identifier) return false;
-  return isDeclaredInEnclosingBlocks(scopeArg.name, scopeArg, loopBody);
+  return isDeclaredInEnclosingBlocks(scopeArg, scopeArg.name, loopBody);
 };

--- a/packages/eslint/src/rules/prevent-construct-id-collision.ts
+++ b/packages/eslint/src/rules/prevent-construct-id-collision.ts
@@ -1,5 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils, TSESTree } from "@typescript-eslint/utils";
 
+import { isDeclaredInEnclosingBlocks } from "../core/ast-node/finder/declared-in-enclosing-blocks";
+import { findEnclosingLoopBody } from "../core/ast-node/finder/enclosing-loop-body";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { createRule } from "../shared/create-rule";
@@ -81,44 +83,6 @@ const validateConstructIdInLoop = (
 };
 
 /**
- * Find the body of the loop that encloses a node.
- * Detects for, for...in, for...of, while, do...while statements,
- * and callbacks of iteration methods (forEach, map, etc.)
- * Returns null when the node is not inside a loop.
- */
-const findEnclosingLoopBody = (node: TSESTree.Node): TSESTree.Node | null => {
-  const parent = node.parent;
-  if (!parent) return null;
-
-  // NOTE: Detect loop statements
-  if (
-    parent.type === AST_NODE_TYPES.ForStatement ||
-    parent.type === AST_NODE_TYPES.ForInStatement ||
-    parent.type === AST_NODE_TYPES.ForOfStatement ||
-    parent.type === AST_NODE_TYPES.WhileStatement ||
-    parent.type === AST_NODE_TYPES.DoWhileStatement
-  ) {
-    return parent.body;
-  }
-
-  // NOTE: Detect iteration method callbacks (ArrowFunction/FunctionExpression)
-  if (
-    (parent.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-      parent.type === AST_NODE_TYPES.FunctionExpression) &&
-    isIterationMethodCallback(parent)
-  ) {
-    return parent.body;
-  }
-
-  // NOTE: Stop at non-constructor method definitions
-  if (parent.type === AST_NODE_TYPES.MethodDefinition && parent.kind !== "constructor") {
-    return null;
-  }
-
-  return findEnclosingLoopBody(parent);
-};
-
-/**
  * Check whether the scope argument is an identifier declared inside the loop body.
  * Only a variable declaration is treated as a per-iteration scope: any other form
  * (`this`, an outer variable, a member expression, ...) may be shared across iterations.
@@ -129,66 +93,4 @@ const isScopeDeclaredInLoopBody = (
 ): boolean => {
   if (scopeArg.type !== AST_NODE_TYPES.Identifier) return false;
   return isDeclaredInEnclosingBlocks(scopeArg.name, scopeArg, loopBody);
-};
-
-/**
- * Check whether a block enclosing the node, up to and including the loop body,
- * declares a variable with the given name
- */
-const isDeclaredInEnclosingBlocks = (
-  name: string,
-  node: TSESTree.Node,
-  loopBody: TSESTree.Node,
-): boolean => {
-  if (declaresVariableName(node, name)) return true;
-  if (node === loopBody || !node.parent) return false;
-  return isDeclaredInEnclosingBlocks(name, node.parent, loopBody);
-};
-
-/**
- * Check whether a block statement declares a variable with the given name
- */
-const declaresVariableName = (node: TSESTree.Node, name: string): boolean => {
-  if (node.type !== AST_NODE_TYPES.BlockStatement) return false;
-
-  return node.body.some(
-    (statement) =>
-      statement.type === AST_NODE_TYPES.VariableDeclaration &&
-      statement.declarations.some(
-        (declarator) =>
-          declarator.id.type === AST_NODE_TYPES.Identifier && declarator.id.name === name,
-      ),
-  );
-};
-
-const ITERATION_METHODS = new Set([
-  "forEach",
-  "map",
-  "flatMap",
-  "filter",
-  "reduce",
-  "reduceRight",
-  "every",
-  "some",
-  "find",
-  "findIndex",
-  "findLast",
-  "findLastIndex",
-]);
-
-/**
- * Check whether an arrow function or function expression is a callback of an iteration method
- */
-const isIterationMethodCallback = (
-  node: TSESTree.ArrowFunctionExpression | TSESTree.FunctionExpression,
-): boolean => {
-  const parent = node.parent;
-  if (parent?.type !== AST_NODE_TYPES.CallExpression) return false;
-
-  const callee = parent.callee;
-  if (callee.type !== AST_NODE_TYPES.MemberExpression) return false;
-
-  if (callee.property.type !== AST_NODE_TYPES.Identifier) return false;
-
-  return ITERATION_METHODS.has(callee.property.name);
 };

--- a/packages/oxlint/src/__tests__/prevent-construct-id-collision.test.ts
+++ b/packages/oxlint/src/__tests__/prevent-construct-id-collision.test.ts
@@ -140,6 +140,54 @@ ruleTester.run("prevent-construct-id-collision", preventConstructIdCollision, {
       }
       `,
     },
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          for (const stage of ["dev", "prod"]) {
+            const stack = new Stack(this, \`\${stage}Stack\`);
+            new Bucket(stack, "Bucket");
+          }
+        }
+      }
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          ["dev", "prod"].forEach((stage) => {
+            const stack = new Stack(this, \`\${stage}Stack\`);
+            new Bucket(stack, "Bucket");
+          });
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {
@@ -227,6 +275,31 @@ ruleTester.run("prevent-construct-id-collision", preventConstructIdCollision, {
         constructor(scope: Construct, id: string) {
           super(scope, id);
           [1, 2, 3].forEach(() => new Bucket(this, \`Bucket\`));
+        }
+      }
+      `,
+      errors: [{ messageId: "preventConstructIdCollision", data: { constructId: "Bucket" } }],
+    },
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const stack = new Stack(this, "Stack");
+          for (const stage of ["dev", "prod"]) {
+            new Bucket(stack, "Bucket");
+          }
         }
       }
       `,

--- a/packages/oxlint/src/__tests__/prevent-construct-id-collision.test.ts
+++ b/packages/oxlint/src/__tests__/prevent-construct-id-collision.test.ts
@@ -305,5 +305,82 @@ ruleTester.run("prevent-construct-id-collision", preventConstructIdCollision, {
       `,
       errors: [{ messageId: "preventConstructIdCollision", data: { constructId: "Bucket" } }],
     },
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const stacks = [new Stack(this, "StackA"), new Stack(this, "StackB")];
+          for (const stack of stacks) {
+            new Bucket(stack, "Bucket");
+          }
+        }
+      }
+      `,
+      errors: [{ messageId: "preventConstructIdCollision", data: { constructId: "Bucket" } }],
+    },
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          const stacks = [new Stack(this, "StackA"), new Stack(this, "StackB")];
+          stacks.forEach((stack) => {
+            new Bucket(stack, "Bucket");
+          });
+        }
+      }
+      `,
+      errors: [{ messageId: "preventConstructIdCollision", data: { constructId: "Bucket" } }],
+    },
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class Bucket extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          for (const stage of ["dev", "prod"]) {
+            const stack = new Stack(this, \`\${stage}Stack\`);
+            for (const name of ["a", "b"]) {
+              new Bucket(stack, "Bucket");
+            }
+          }
+        }
+      }
+      `,
+      errors: [{ messageId: "preventConstructIdCollision", data: { constructId: "Bucket" } }],
+    },
   ],
 });

--- a/packages/oxlint/src/core/ast-node/finder/declared-in-enclosing-blocks.ts
+++ b/packages/oxlint/src/core/ast-node/finder/declared-in-enclosing-blocks.ts
@@ -5,19 +5,19 @@ import { AST_NODE_TYPES } from "corsa-oxlint";
 /**
  * Check whether a variable of a given name is declared by a VariableDeclaration in one of
  * the block statements enclosing a node, searching up to a given ancestor (inclusive).
- * @param name The variable name to look for
  * @param node The node to start searching from
+ * @param name The variable name to look for
  * @param ancestor The node at which the search stops
  * @returns true if an enclosing block declares the variable
  */
 export const isDeclaredInEnclosingBlocks = (
-  name: string,
   node: ESTree.Node,
+  name: string,
   ancestor: ESTree.Node,
 ): boolean => {
   if (declaresVariableName(node, name)) return true;
   if (node === ancestor || !node.parent) return false;
-  return isDeclaredInEnclosingBlocks(name, node.parent, ancestor);
+  return isDeclaredInEnclosingBlocks(node.parent, name, ancestor);
 };
 
 /**

--- a/packages/oxlint/src/core/ast-node/finder/declared-in-enclosing-blocks.ts
+++ b/packages/oxlint/src/core/ast-node/finder/declared-in-enclosing-blocks.ts
@@ -1,0 +1,37 @@
+import type { ESTree } from "corsa-oxlint";
+
+import { AST_NODE_TYPES } from "corsa-oxlint";
+
+/**
+ * Check whether a variable of a given name is declared by a VariableDeclaration in one of
+ * the block statements enclosing a node, searching up to a given ancestor (inclusive).
+ * @param name The variable name to look for
+ * @param node The node to start searching from
+ * @param ancestor The node at which the search stops
+ * @returns true if an enclosing block declares the variable
+ */
+export const isDeclaredInEnclosingBlocks = (
+  name: string,
+  node: ESTree.Node,
+  ancestor: ESTree.Node,
+): boolean => {
+  if (declaresVariableName(node, name)) return true;
+  if (node === ancestor || !node.parent) return false;
+  return isDeclaredInEnclosingBlocks(name, node.parent, ancestor);
+};
+
+/**
+ * Check whether a block statement declares a variable with the given name
+ */
+const declaresVariableName = (node: ESTree.Node, name: string): boolean => {
+  if (node.type !== AST_NODE_TYPES.BlockStatement) return false;
+
+  return node.body.some(
+    (statement) =>
+      statement.type === AST_NODE_TYPES.VariableDeclaration &&
+      statement.declarations.some(
+        (declarator) =>
+          declarator.id.type === AST_NODE_TYPES.Identifier && declarator.id.name === name,
+      ),
+  );
+};

--- a/packages/oxlint/src/core/ast-node/finder/enclosing-loop-body.ts
+++ b/packages/oxlint/src/core/ast-node/finder/enclosing-loop-body.ts
@@ -1,0 +1,74 @@
+import type { ESTree } from "corsa-oxlint";
+
+import { AST_NODE_TYPES } from "corsa-oxlint";
+
+const ITERATION_METHODS = new Set([
+  "forEach",
+  "map",
+  "flatMap",
+  "filter",
+  "reduce",
+  "reduceRight",
+  "every",
+  "some",
+  "find",
+  "findIndex",
+  "findLast",
+  "findLastIndex",
+]);
+
+/**
+ * Find the body of the loop enclosing a given node.
+ * Detects for, for...in, for...of, while, do...while statements,
+ * and callbacks of iteration methods (forEach, map, etc.)
+ * @param node The node to start searching from
+ * @returns The enclosing loop body or null if the node is not inside a loop
+ */
+export const findEnclosingLoopBody = (node: ESTree.Node): ESTree.Node | null => {
+  const parent = node.parent;
+  if (!parent) return null;
+
+  // NOTE: Detect loop statements
+  if (
+    parent.type === AST_NODE_TYPES.ForStatement ||
+    parent.type === AST_NODE_TYPES.ForInStatement ||
+    parent.type === AST_NODE_TYPES.ForOfStatement ||
+    parent.type === AST_NODE_TYPES.WhileStatement ||
+    parent.type === AST_NODE_TYPES.DoWhileStatement
+  ) {
+    return parent.body;
+  }
+
+  // NOTE: Detect iteration method callbacks (ArrowFunction/FunctionExpression)
+  if (
+    (parent.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+      parent.type === AST_NODE_TYPES.FunctionExpression) &&
+    isIterationMethodCallback(parent)
+  ) {
+    return parent.body;
+  }
+
+  // NOTE: Stop at non-constructor method definitions
+  if (parent.type === AST_NODE_TYPES.MethodDefinition && parent.kind !== "constructor") {
+    return null;
+  }
+
+  return findEnclosingLoopBody(parent);
+};
+
+/**
+ * Check whether an arrow function or function expression is a callback of an iteration method
+ */
+const isIterationMethodCallback = (
+  node: ESTree.ArrowFunctionExpression | ESTree.FunctionExpression,
+): boolean => {
+  const parent = node.parent;
+  if (parent?.type !== AST_NODE_TYPES.CallExpression) return false;
+
+  const callee = parent.callee;
+  if (callee.type !== AST_NODE_TYPES.MemberExpression) return false;
+
+  if (callee.property.type !== AST_NODE_TYPES.Identifier) return false;
+
+  return ITERATION_METHODS.has(callee.property.name);
+};

--- a/packages/oxlint/src/core/ast-node/finder/enclosing-loop-body.ts
+++ b/packages/oxlint/src/core/ast-node/finder/enclosing-loop-body.ts
@@ -24,6 +24,9 @@ const ITERATION_METHODS = new Set([
  * @param node The node to start searching from
  * @returns The enclosing loop body or null if the node is not inside a loop
  */
+// NOTE: The other node finders return `undefined`, but the remapped node types reject both
+// `ESTree.Node | undefined` (TS2322) and `ESTree.Statement | ESTree.Expression | undefined`
+// (TS2719) for the iteration callback body, so this finder uses `null` in both plugins
 export const findEnclosingLoopBody = (node: ESTree.Node): ESTree.Node | null => {
   const parent = node.parent;
   if (!parent) return null;

--- a/packages/oxlint/src/rules/prevent-construct-id-collision.ts
+++ b/packages/oxlint/src/rules/prevent-construct-id-collision.ts
@@ -58,7 +58,7 @@ const validateConstructIdInLoop = (
   if (!loopBody) return;
 
   // NOTE: A scope declared inside the loop body is re-created on every iteration,
-  //       so a literal ID cannot collide within it
+  // so a literal ID cannot collide within it
   if (isScopeDeclaredInLoopBody(node.arguments[0], loopBody)) return;
 
   const secondArg = node.arguments[1];
@@ -95,5 +95,5 @@ const isScopeDeclaredInLoopBody = (
   loopBody: ESTree.Node,
 ): boolean => {
   if (scopeArg.type !== AST_NODE_TYPES.Identifier) return false;
-  return isDeclaredInEnclosingBlocks(scopeArg.name, scopeArg, loopBody);
+  return isDeclaredInEnclosingBlocks(scopeArg, scopeArg.name, loopBody);
 };

--- a/packages/oxlint/src/rules/prevent-construct-id-collision.ts
+++ b/packages/oxlint/src/rules/prevent-construct-id-collision.ts
@@ -52,7 +52,12 @@ const validateConstructIdInLoop = (
   node: ESTree.NewExpression,
   context: RuleContext<"preventConstructIdCollision">,
 ) => {
-  if (!isInsideLoop(node)) return;
+  const loopBody = findEnclosingLoopBody(node);
+  if (!loopBody) return;
+
+  // NOTE: A scope declared inside the loop body is re-created on every iteration,
+  //       so a literal ID cannot collide within it
+  if (isScopeDeclaredInLoopBody(node.arguments[0], loopBody)) return;
 
   const secondArg = node.arguments[1];
 
@@ -79,38 +84,81 @@ const validateConstructIdInLoop = (
 };
 
 /**
- * Check whether a node is inside a loop.
+ * Find the body of the loop that encloses a node.
  * Detects for, for...in, for...of, while, do...while statements,
  * and callbacks of iteration methods (forEach, map, etc.)
+ * Returns null when the node is not inside a loop.
  */
-const isInsideLoop = (node: ESTree.Node): boolean => {
-  let current = node.parent;
-  while (current) {
-    if (
-      current.type === AST_NODE_TYPES.ForStatement ||
-      current.type === AST_NODE_TYPES.ForInStatement ||
-      current.type === AST_NODE_TYPES.ForOfStatement ||
-      current.type === AST_NODE_TYPES.WhileStatement ||
-      current.type === AST_NODE_TYPES.DoWhileStatement
-    ) {
-      return true;
-    }
+const findEnclosingLoopBody = (node: ESTree.Node): ESTree.Node | null => {
+  const parent = node.parent;
+  if (!parent) return null;
 
-    if (
-      (current.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-        current.type === AST_NODE_TYPES.FunctionExpression) &&
-      isIterationMethodCallback(current)
-    ) {
-      return true;
-    }
-
-    if (current.type === AST_NODE_TYPES.MethodDefinition && current.kind !== "constructor") {
-      return false;
-    }
-
-    current = current.parent;
+  if (
+    parent.type === AST_NODE_TYPES.ForStatement ||
+    parent.type === AST_NODE_TYPES.ForInStatement ||
+    parent.type === AST_NODE_TYPES.ForOfStatement ||
+    parent.type === AST_NODE_TYPES.WhileStatement ||
+    parent.type === AST_NODE_TYPES.DoWhileStatement
+  ) {
+    return parent.body;
   }
-  return false;
+
+  if (
+    (parent.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+      parent.type === AST_NODE_TYPES.FunctionExpression) &&
+    isIterationMethodCallback(parent)
+  ) {
+    return parent.body;
+  }
+
+  if (parent.type === AST_NODE_TYPES.MethodDefinition && parent.kind !== "constructor") {
+    return null;
+  }
+
+  return findEnclosingLoopBody(parent);
+};
+
+/**
+ * Check whether the scope argument is an identifier declared inside the loop body.
+ * Only a variable declaration is treated as a per-iteration scope: any other form
+ * (`this`, an outer variable, a member expression, ...) may be shared across iterations.
+ */
+const isScopeDeclaredInLoopBody = (
+  scopeArg: ESTree.NewExpression["arguments"][number],
+  loopBody: ESTree.Node,
+): boolean => {
+  if (scopeArg.type !== AST_NODE_TYPES.Identifier) return false;
+  return isDeclaredInEnclosingBlocks(scopeArg.name, scopeArg, loopBody);
+};
+
+/**
+ * Check whether a block enclosing the node, up to and including the loop body,
+ * declares a variable with the given name
+ */
+const isDeclaredInEnclosingBlocks = (
+  name: string,
+  node: ESTree.Node,
+  loopBody: ESTree.Node,
+): boolean => {
+  if (declaresVariableName(node, name)) return true;
+  if (node === loopBody || !node.parent) return false;
+  return isDeclaredInEnclosingBlocks(name, node.parent, loopBody);
+};
+
+/**
+ * Check whether a block statement declares a variable with the given name
+ */
+const declaresVariableName = (node: ESTree.Node, name: string): boolean => {
+  if (node.type !== AST_NODE_TYPES.BlockStatement) return false;
+
+  return node.body.some(
+    (statement) =>
+      statement.type === AST_NODE_TYPES.VariableDeclaration &&
+      statement.declarations.some(
+        (declarator) =>
+          declarator.id.type === AST_NODE_TYPES.Identifier && declarator.id.name === name,
+      ),
+  );
 };
 
 const ITERATION_METHODS = new Set([

--- a/packages/oxlint/src/rules/prevent-construct-id-collision.ts
+++ b/packages/oxlint/src/rules/prevent-construct-id-collision.ts
@@ -2,6 +2,8 @@ import type { ESTree, RuleContext } from "corsa-oxlint";
 
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
+import { isDeclaredInEnclosingBlocks } from "../core/ast-node/finder/declared-in-enclosing-blocks";
+import { findEnclosingLoopBody } from "../core/ast-node/finder/enclosing-loop-body";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { createRule } from "../shared/create-rule";
@@ -84,41 +86,6 @@ const validateConstructIdInLoop = (
 };
 
 /**
- * Find the body of the loop that encloses a node.
- * Detects for, for...in, for...of, while, do...while statements,
- * and callbacks of iteration methods (forEach, map, etc.)
- * Returns null when the node is not inside a loop.
- */
-const findEnclosingLoopBody = (node: ESTree.Node): ESTree.Node | null => {
-  const parent = node.parent;
-  if (!parent) return null;
-
-  if (
-    parent.type === AST_NODE_TYPES.ForStatement ||
-    parent.type === AST_NODE_TYPES.ForInStatement ||
-    parent.type === AST_NODE_TYPES.ForOfStatement ||
-    parent.type === AST_NODE_TYPES.WhileStatement ||
-    parent.type === AST_NODE_TYPES.DoWhileStatement
-  ) {
-    return parent.body;
-  }
-
-  if (
-    (parent.type === AST_NODE_TYPES.ArrowFunctionExpression ||
-      parent.type === AST_NODE_TYPES.FunctionExpression) &&
-    isIterationMethodCallback(parent)
-  ) {
-    return parent.body;
-  }
-
-  if (parent.type === AST_NODE_TYPES.MethodDefinition && parent.kind !== "constructor") {
-    return null;
-  }
-
-  return findEnclosingLoopBody(parent);
-};
-
-/**
  * Check whether the scope argument is an identifier declared inside the loop body.
  * Only a variable declaration is treated as a per-iteration scope: any other form
  * (`this`, an outer variable, a member expression, ...) may be shared across iterations.
@@ -129,66 +96,4 @@ const isScopeDeclaredInLoopBody = (
 ): boolean => {
   if (scopeArg.type !== AST_NODE_TYPES.Identifier) return false;
   return isDeclaredInEnclosingBlocks(scopeArg.name, scopeArg, loopBody);
-};
-
-/**
- * Check whether a block enclosing the node, up to and including the loop body,
- * declares a variable with the given name
- */
-const isDeclaredInEnclosingBlocks = (
-  name: string,
-  node: ESTree.Node,
-  loopBody: ESTree.Node,
-): boolean => {
-  if (declaresVariableName(node, name)) return true;
-  if (node === loopBody || !node.parent) return false;
-  return isDeclaredInEnclosingBlocks(name, node.parent, loopBody);
-};
-
-/**
- * Check whether a block statement declares a variable with the given name
- */
-const declaresVariableName = (node: ESTree.Node, name: string): boolean => {
-  if (node.type !== AST_NODE_TYPES.BlockStatement) return false;
-
-  return node.body.some(
-    (statement) =>
-      statement.type === AST_NODE_TYPES.VariableDeclaration &&
-      statement.declarations.some(
-        (declarator) =>
-          declarator.id.type === AST_NODE_TYPES.Identifier && declarator.id.name === name,
-      ),
-  );
-};
-
-const ITERATION_METHODS = new Set([
-  "forEach",
-  "map",
-  "flatMap",
-  "filter",
-  "reduce",
-  "reduceRight",
-  "every",
-  "some",
-  "find",
-  "findIndex",
-  "findLast",
-  "findLastIndex",
-]);
-
-/**
- * Check whether an arrow function or function expression is a callback of an iteration method
- */
-const isIterationMethodCallback = (
-  node: ESTree.ArrowFunctionExpression | ESTree.FunctionExpression,
-): boolean => {
-  const parent = node.parent;
-  if (parent?.type !== AST_NODE_TYPES.CallExpression) return false;
-
-  const callee = parent.callee;
-  if (callee.type !== AST_NODE_TYPES.MemberExpression) return false;
-
-  if (callee.property.type !== AST_NODE_TYPES.Identifier) return false;
-
-  return ITERATION_METHODS.has(callee.property.name);
 };


### PR DESCRIPTION
### Issue # (if applicable)

Closes #569.

### Reason for this change

`prevent-construct-id-collision` looked only at the Construct ID and at whether the `new` expression is lexically inside a loop, never at the scope argument. Construct IDs only have to be unique within a scope, so a literal ID cannot collide when the scope itself is created on every iteration — yet that already-correct code was reported, pushing users to change logical IDs for no reason.

### Description of changes

- Skip the report when the scope argument is an identifier declared by a variable declaration in a block enclosing the `new` expression, up to and including the enclosing loop body. Every other scope shape keeps reporting.
- Loop detection moves to a new core finder `core/ast-node/finder/enclosing-loop-body.ts` (`findEnclosingLoopBody`), which returns the enclosing loop body — loop statement body or iteration-method callback body — instead of the previous boolean. The set of loop nodes and the `MethodDefinition` stop condition are unchanged; `ITERATION_METHODS` and `isIterationMethodCallback` move along with it.
- The declaration lookup moves to a new core finder `core/ast-node/finder/declared-in-enclosing-blocks.ts` (`isDeclaredInEnclosingBlocks`), generic over any ancestor. The rule file keeps only rule policy: the rule definition, `validateConstructIdInLoop`, and `isScopeDeclaredInLoopBody` composed from the two finders.
- Mirrored in both plugins.

### Description of how you validated changes

- Valid cases: a per-iteration scope in `for...of` and in a `forEach` callback. Confirmed both fail without the rule change.
- Invalid cases pinning the conservative boundary: a scope declared outside the loop, the loop binding used as scope (`for (const stack of stacks)`), an iteration-callback parameter used as scope (`stacks.forEach((stack) => ...)`), and a scope declared in an outer loop with the `new` in an inner loop. All four still report.
- Pre-existing expectations are unchanged (`this` scope inside a loop and a template literal without expressions still report).
- `vp check` and `vp test --run` (722/722) pass, and `vp run -r pack && bash scripts/integration-test.sh` reports the expected 43 errors for all three integration targets. Verified on corsa-oxlint 1.12.4 / oxlint 1.80.0 / vite-plus 0.3.0 after rebasing onto `main`.

### Review points

The exemption boundary is deliberately narrow — please confirm it is where you want it.

Exempted (no longer reported): the scope argument is an `Identifier` whose declaration is a `VariableDeclaration` in a block enclosing the `new` expression, up to and including the loop body.

Still reported (each pinned by a test): `this`, member expressions (`this.group`), call results, any non-identifier scope, an identifier declared outside the loop body, the loop's own binding, iteration-callback parameters — iterated values can repeat, so a collision is still possible there — and a scope declared in an outer loop when the `new` sits in an inner loop, where the inner iterations do share one scope.

Known trade-offs of this boundary:

- An alias declared inside the loop that points at an outer scope (`const stack = outerStack;`) is exempted even though it can collide.
- The declaration lookup is a lexical block walk by name, not full scope resolution, so destructured bindings (`const { stack } = ...`) are not treated as declarations and keep reporting.

One convention deviation to confirm: the other node finders in `core/ast-node/finder/` return `| undefined`, but `findEnclosingLoopBody` returns `| null` in both plugins. In the oxlint plugin the remapped node types reject the iteration-callback body for `ESTree.Node | undefined` (TS2322) and for `ESTree.Statement | ESTree.Expression | undefined` (TS2719, two unrelated `ArrayExpression` identities); `| null` type-checks, so both plugins keep `null` rather than diverging. A NOTE in the oxlint finder records this.

Note: #585 also edits this rule file (it swaps `isConstructType` for `isConstructTypeIgnoringSubclasses` at the `NewExpression` call site). Whichever lands second will need a small conflict resolution there; this PR does not touch that line.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
