### PR TITLE
fix: track props properties when the props parameter is optional

### DIFF
--- a/packages/eslint/src/__tests__/no-unused-props.test.ts
+++ b/packages/eslint/src/__tests__/no-unused-props.test.ts
@@ -179,6 +179,24 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       `,
     },
     {
+      name: "Optional props parameter: all properties are used",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName?: string;
+        enableVersioning?: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props?: MyConstructProps) {
+          super(scope, id);
+          console.log(props?.bucketName, props?.enableVersioning);
+        }
+      }
+      `,
+    },
+    {
       name: "Some properties are unused but class is abstract",
       code: `
       class Construct {}
@@ -1236,6 +1254,82 @@ ruleTester.run("no-unused-props", noUnusedProps, {
 
       export class MyConstruct extends Construct {
         constructor(scope: Construct, id: string, props: MyConstructProps = {} as MyConstructProps) {
+          super(scope, id);
+          console.log(props.bucketName);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "Required props parameter with optional properties: some properties are unused",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName?: string;
+        unusedProp?: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          console.log(props.bucketName);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "Optional props parameter: some properties are unused",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName?: string;
+        unusedProp?: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props?: MyConstructProps) {
+          super(scope, id);
+          console.log(props?.bucketName);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "Props parameter typed as a union with undefined: some properties are unused",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName?: string;
+        unusedProp?: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps | undefined) {
+          super(scope, id);
+          console.log(props?.bucketName);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "Props parameter with an empty object default value: some properties are unused",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName?: string;
+        unusedProp?: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps = {}) {
           super(scope, id);
           console.log(props.bucketName);
         }

--- a/packages/eslint/src/core/ts-type/finder/non-nullable-type.ts
+++ b/packages/eslint/src/core/ts-type/finder/non-nullable-type.ts
@@ -2,9 +2,9 @@ import { Type, TypeChecker } from "typescript";
 
 /**
  * Find the non-nullable form of a type (e.g. `Topic | undefined` -> `Topic`)
- * @param type - The type to strip `undefined` / `null` from
+ * @param type - The type to strip `undefined` / `null` / `void` from
  * @param checker - The TypeScript type checker
- * @returns The type without its `undefined` / `null` members
+ * @returns The type without its `undefined` / `null` / `void` members
  */
 export const findNonNullableType = (type: Type, checker: TypeChecker): Type => {
   return checker.getNonNullableType(type);

--- a/packages/eslint/src/core/ts-type/finder/non-nullable-type.ts
+++ b/packages/eslint/src/core/ts-type/finder/non-nullable-type.ts
@@ -1,0 +1,11 @@
+import { Type, TypeChecker } from "typescript";
+
+/**
+ * Find the non-nullable form of a type (e.g. `Topic | undefined` -> `Topic`)
+ * @param type - The type to strip `undefined` / `null` from
+ * @param checker - The TypeScript type checker
+ * @returns The type without its `undefined` / `null` members
+ */
+export const findNonNullableType = (type: Type, checker: TypeChecker): Type => {
+  return checker.getNonNullableType(type);
+};

--- a/packages/eslint/src/rules/no-unused-props/index.ts
+++ b/packages/eslint/src/rules/no-unused-props/index.ts
@@ -5,7 +5,7 @@ import {
   TSESLint,
   TSESTree,
 } from "@typescript-eslint/utils";
-import { Type } from "typescript";
+import { Type, TypeChecker } from "typescript";
 
 import { findConstructor } from "../../core/ast-node/finder/constructor";
 import { findConstructorParamIdentifier } from "../../core/ast-node/finder/constructor-param-identifier";
@@ -44,6 +44,7 @@ export const noUnusedProps = createRule({
   defaultOptions: [],
   create(context) {
     const parserServices = ESLintUtils.getParserServices(context);
+    const checker = parserServices.program.getTypeChecker();
 
     return {
       ClassDeclaration(node) {
@@ -55,7 +56,7 @@ export const noUnusedProps = createRule({
         const constructor = findConstructor(node);
         if (!constructor) return;
 
-        const propsParam = getPropsParam(constructor, parserServices);
+        const propsParam = getPropsParam(constructor, parserServices, checker);
         if (!propsParam) return;
         if (isPropsUsedInSuperCall(constructor, propsParam.identifier.name)) return;
 
@@ -74,6 +75,7 @@ export const noUnusedProps = createRule({
 const getPropsParam = (
   constructor: TSESTree.MethodDefinition,
   parserServices: ParserServicesWithTypeInformation,
+  checker: TypeChecker,
 ): PropsParam | null => {
   const params = constructor.value.params;
   if (params.length < 3) return null;
@@ -90,7 +92,10 @@ const getPropsParam = (
   return {
     identifier,
     reportNode: propsParam,
-    type: parserServices.getTypeAtLocation(identifier),
+    // NOTE: An optional parameter (e.g. `props?: MyConstructProps`) is typed as the union
+    // `MyConstructProps | undefined`, which only exposes the properties shared by every union
+    // member (none). Strip the nullish members so the declared properties are tracked.
+    type: checker.getNonNullableType(parserServices.getTypeAtLocation(identifier)),
     isParameterProperty,
   };
 };

--- a/packages/eslint/src/rules/no-unused-props/index.ts
+++ b/packages/eslint/src/rules/no-unused-props/index.ts
@@ -10,6 +10,7 @@ import { Type, TypeChecker } from "typescript";
 import { findConstructor } from "../../core/ast-node/finder/constructor";
 import { findConstructorParamIdentifier } from "../../core/ast-node/finder/constructor-param-identifier";
 import { isConstructType } from "../../core/cdk-construct/type-checker/is-construct";
+import { findNonNullableType } from "../../core/ts-type/finder/non-nullable-type";
 import { createRule } from "../../shared/create-rule";
 import { PropsUsageAnalyzer } from "./props-usage-analyzer";
 import { IPropsUsageTracker, PropsUsageTracker } from "./props-usage-tracker";
@@ -95,7 +96,7 @@ const getPropsParam = (
     // NOTE: An optional parameter (e.g. `props?: MyConstructProps`) is typed as the union
     // `MyConstructProps | undefined`, which only exposes the properties shared by every union
     // member (none). Strip the nullish members so the declared properties are tracked.
-    type: checker.getNonNullableType(parserServices.getTypeAtLocation(identifier)),
+    type: findNonNullableType(parserServices.getTypeAtLocation(identifier), checker),
     isParameterProperty,
   };
 };

--- a/packages/oxlint/src/__tests__/no-unused-props.test.ts
+++ b/packages/oxlint/src/__tests__/no-unused-props.test.ts
@@ -173,6 +173,24 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       `,
     },
     {
+      name: "Optional props parameter: all properties are used",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName?: string;
+        enableVersioning?: boolean;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props?: MyConstructProps) {
+          super(scope, id);
+          console.log(props?.bucketName, props?.enableVersioning);
+        }
+      }
+      `,
+    },
+    {
       name: "Some properties are unused but class is abstract",
       code: `
       class Construct {}
@@ -1230,6 +1248,82 @@ ruleTester.run("no-unused-props", noUnusedProps, {
 
       export class MyConstruct extends Construct {
         constructor(scope: Construct, id: string, props: MyConstructProps = {} as MyConstructProps) {
+          super(scope, id);
+          console.log(props.bucketName);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "Required props parameter with optional properties: some properties are unused",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName?: string;
+        unusedProp?: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          console.log(props.bucketName);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "Optional props parameter: some properties are unused",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName?: string;
+        unusedProp?: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props?: MyConstructProps) {
+          super(scope, id);
+          console.log(props?.bucketName);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "Props parameter typed as a union with undefined: some properties are unused",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName?: string;
+        unusedProp?: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps | undefined) {
+          super(scope, id);
+          console.log(props?.bucketName);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
+    {
+      name: "Props parameter with an empty object default value: some properties are unused",
+      code: `
+      class Construct {}
+
+      interface MyConstructProps {
+        bucketName?: string;
+        unusedProp?: string;
+      }
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps = {}) {
           super(scope, id);
           console.log(props.bucketName);
         }

--- a/packages/oxlint/src/core/ts-type/finder/non-nullable-type.ts
+++ b/packages/oxlint/src/core/ts-type/finder/non-nullable-type.ts
@@ -1,0 +1,21 @@
+import type { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
+
+const NULLISH_TYPE_NAMES = ["undefined", "null"];
+
+/**
+ * Find the non-nullable form of a type (e.g. `Topic | undefined` -> `Topic`).
+ * A union that still holds more than one member after `undefined` / `null` are removed is
+ * returned unchanged, because no single member describes the value on its own.
+ * @param type - The type to strip `undefined` / `null` from
+ * @param checker - The corsa-oxlint type checker
+ * @returns The type without its `undefined` / `null` members
+ */
+export const findNonNullableType = (type: CorsaType, checker: CorsaTypeCheckerShape) => {
+  if (!checker.isUnionType(type)) return type;
+
+  const nonNullishTypes = checker
+    .getTypesOfType(type)
+    .filter((member) => !NULLISH_TYPE_NAMES.includes(checker.typeToString(member)));
+
+  return nonNullishTypes.length === 1 ? nonNullishTypes[0] : type;
+};

--- a/packages/oxlint/src/core/ts-type/finder/non-nullable-type.ts
+++ b/packages/oxlint/src/core/ts-type/finder/non-nullable-type.ts
@@ -1,14 +1,14 @@
 import type { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
 
-const NULLISH_TYPE_NAMES = ["undefined", "null"];
+const NULLISH_TYPE_NAMES = ["undefined", "null", "void"];
 
 /**
  * Find the non-nullable form of a type (e.g. `Topic | undefined` -> `Topic`).
- * A union that still holds more than one member after `undefined` / `null` are removed is
+ * A union that still holds more than one member after `undefined` / `null` / `void` are removed is
  * returned unchanged, because no single member describes the value on its own.
- * @param type - The type to strip `undefined` / `null` from
+ * @param type - The type to strip `undefined` / `null` / `void` from
  * @param checker - The corsa-oxlint type checker
- * @returns The type without its `undefined` / `null` members
+ * @returns The type without its `undefined` / `null` / `void` members
  */
 export const findNonNullableType = (type: CorsaType, checker: CorsaTypeCheckerShape) => {
   if (!checker.isUnionType(type)) return type;

--- a/packages/oxlint/src/rules/no-unused-props/index.ts
+++ b/packages/oxlint/src/rules/no-unused-props/index.ts
@@ -1,4 +1,10 @@
-import type { ESTree, ParserServices, RuleContext } from "corsa-oxlint";
+import type {
+  CorsaType,
+  CorsaTypeCheckerShape,
+  ESTree,
+  ParserServices,
+  RuleContext,
+} from "corsa-oxlint";
 
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
@@ -41,7 +47,7 @@ export const noUnusedProps = createRule({
         const constructor = findConstructor(node);
         if (!constructor) return;
 
-        const propsParam = getPropsParam(constructor, parserServices);
+        const propsParam = getPropsParam(constructor, parserServices, checker);
         if (!propsParam) return;
         if (isPropsUsedInSuperCall(constructor, propsParam.identifier.name)) return;
 
@@ -57,7 +63,11 @@ export const noUnusedProps = createRule({
   },
 });
 
-const getPropsParam = (constructor: ESTree.MethodDefinition, parserServices: ParserServices) => {
+const getPropsParam = (
+  constructor: ESTree.MethodDefinition,
+  parserServices: ParserServices,
+  checker: CorsaTypeCheckerShape,
+) => {
   const params = constructor.value.params;
   if (params.length < 3) return null;
 
@@ -76,9 +86,30 @@ const getPropsParam = (constructor: ESTree.MethodDefinition, parserServices: Par
   return {
     identifier,
     reportNode: propsParam,
-    type,
+    type: getNonNullableType(type, checker),
     isParameterProperty,
   };
+};
+
+/**
+ * Removes the nullish members of a props parameter type
+ *
+ * An optional parameter (e.g. `props?: MyConstructProps`) is typed as the union
+ * `MyConstructProps | undefined`, which only exposes the properties shared by every union member
+ * (none). The corsa type checker has no `getNonNullableType`, so the union is unwrapped here.
+ */
+const getNonNullableType = (type: CorsaType, checker: CorsaTypeCheckerShape) => {
+  if (!checker.isUnionType(type)) return type;
+
+  const members = checker.getTypesOfType(type).filter((member) => !isNullishType(member, checker));
+  // NOTE: A union of several non-nullish members keeps the checker's own semantics (the
+  // properties shared by every member), so it is left untouched
+  return members.length === 1 ? members[0] : type;
+};
+
+const isNullishType = (type: CorsaType, checker: CorsaTypeCheckerShape): boolean => {
+  const typeText = checker.typeToString(type);
+  return typeText === "undefined" || typeText === "null";
 };
 
 /**

--- a/packages/oxlint/src/rules/no-unused-props/index.ts
+++ b/packages/oxlint/src/rules/no-unused-props/index.ts
@@ -1,16 +1,11 @@
-import type {
-  CorsaType,
-  CorsaTypeCheckerShape,
-  ESTree,
-  ParserServices,
-  RuleContext,
-} from "corsa-oxlint";
+import type { CorsaTypeCheckerShape, ESTree, ParserServices, RuleContext } from "corsa-oxlint";
 
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findConstructor } from "../../core/ast-node/finder/constructor";
 import { findConstructorParamIdentifier } from "../../core/ast-node/finder/constructor-param-identifier";
 import { isConstructType } from "../../core/cdk-construct/type-checker/is-construct";
+import { findNonNullableType } from "../../core/ts-type/finder/non-nullable-type";
 import { createRule } from "../../shared/create-rule";
 import { PropsUsageAnalyzer } from "./props-usage-analyzer";
 import { IPropsUsageTracker, PropsUsageTracker } from "./props-usage-tracker";
@@ -86,30 +81,12 @@ const getPropsParam = (
   return {
     identifier,
     reportNode: propsParam,
-    type: getNonNullableType(type, checker),
+    // NOTE: An optional parameter (e.g. `props?: MyConstructProps`) is typed as the union
+    // `MyConstructProps | undefined`, which only exposes the properties shared by every union
+    // member (none). Strip the nullish members so the declared properties are tracked.
+    type: findNonNullableType(type, checker),
     isParameterProperty,
   };
-};
-
-/**
- * Removes the nullish members of a props parameter type
- *
- * An optional parameter (e.g. `props?: MyConstructProps`) is typed as the union
- * `MyConstructProps | undefined`, which only exposes the properties shared by every union member
- * (none). The corsa type checker has no `getNonNullableType`, so the union is unwrapped here.
- */
-const getNonNullableType = (type: CorsaType, checker: CorsaTypeCheckerShape) => {
-  if (!checker.isUnionType(type)) return type;
-
-  const members = checker.getTypesOfType(type).filter((member) => !isNullishType(member, checker));
-  // NOTE: A union of several non-nullish members keeps the checker's own semantics (the
-  // properties shared by every member), so it is left untouched
-  return members.length === 1 ? members[0] : type;
-};
-
-const isNullishType = (type: CorsaType, checker: CorsaTypeCheckerShape): boolean => {
-  const typeText = checker.typeToString(type);
-  return typeText === "undefined" || typeText === "null";
 };
 
 /**


### PR DESCRIPTION
### Issue # (if applicable)

Closes #567.

### Reason for this change

An optional props parameter (`props?: MyConstructProps`, the canonical shape for all-optional
props) is typed as the union `MyConstructProps | undefined`, and a union only exposes the
properties shared by every member — none. `PropsUsageTracker` was therefore initialised with an
empty property map, so `no-unused-props` silently reported nothing for those constructors, in
both plugins.

### Description of changes

- Strip the `undefined` / `null` / `void` members of the props parameter type before collecting
  its properties, so an optional parameter is analyzed exactly like the required one.
- The stripping goes through the shared `core/ts-type/finder/non-nullable-type` finder
  (`checker.getNonNullableType` for ESLint; for Oxlint, where the corsa checker has no
  equivalent, the union members are filtered by name). The finder is shared with #586 and the
  files added here are byte-identical to that PR's, so whichever lands first the other merges
  cleanly.
- A union that still holds several members after the nullish ones are removed is left unchanged.
  This is where the two plugins diverge, by checker capability: for `props: A | B | undefined`,
  ESLint tracks the properties `A` and `B` have in common (`getNonNullableType` returns the
  narrowed union `A | B`), while Oxlint tracks nothing, because corsa cannot build a union type
  and the finder therefore returns the original union. `props?: A | B` is rare in CDK code, so
  both plugins stay conservative here (no false positives either way).

### Description of how you validated changes

- Added, per plugin, an invalid case for `props?: P` and for `props: P | undefined`, a valid case
  for `props?: P` with every property used, and required-parameter / `props: P = {}` controls.
  The two nullable cases fail on `main` and pass with this change; the controls pass on both.
- `vp check`, `vp test --run` (720/720) and the integration suite (43 errors on the examples
  workspace, unchanged) pass.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
