### PR TITLE
fix: treat Stack subclasses as Constructs in class-level rule checks

### DIFF
--- a/packages/eslint/src/__tests__/construct-constructor-property.test.ts
+++ b/packages/eslint/src/__tests__/construct-constructor-property.test.ts
@@ -137,6 +137,51 @@ ruleTester.run("construct-constructor-property", constructConstructorProperty, {
       }
       `,
     },
+    {
+      name: "class extends App, whose constructor takes props instead of scope and id",
+      code: `
+      class Construct {}
+      interface AppProps {}
+      class App extends Construct {
+        constructor(props?: AppProps) {
+          super();
+        }
+      }
+
+      export class MyApp extends App {
+        constructor(props?: AppProps) {
+          super(props);
+        }
+      }
+      `,
+    },
+    {
+      name: "first parameter is typed as Stack",
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Stack, id: string) {
+          super(scope, id);
+        }
+      }
+      `,
+    },
+    {
+      name: "first parameter is typed as a Stack subclass",
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+      class MyStack extends Stack {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: MyStack, id: string) {
+          super(scope, id);
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {
@@ -278,6 +323,23 @@ ruleTester.run("construct-constructor-property", constructConstructorProperty, {
       `,
       errors: [
         { messageId: "invalidConstructorProperty" },
+        { messageId: "invalidConstructorProperty" },
+        { messageId: "invalidConstructorProperty" },
+      ],
+    },
+    {
+      name: "class extending Stack has invalid constructor property names",
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+
+      export class BadStack extends Stack {
+        constructor(myScope: Construct, myId: string) {
+          super(myScope, myId);
+        }
+      }
+      `,
+      errors: [
         { messageId: "invalidConstructorProperty" },
         { messageId: "invalidConstructorProperty" },
       ],

--- a/packages/eslint/src/__tests__/no-unused-props.test.ts
+++ b/packages/eslint/src/__tests__/no-unused-props.test.ts
@@ -1408,5 +1408,25 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       `,
       errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
     },
+    {
+      name: "Class extending Stack: some properties are unused",
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+
+      interface MyStackProps {
+        usedProp: string;
+        unusedProp: string;
+      }
+
+      export class MyStack extends Stack {
+        constructor(scope: Construct, id: string, props: MyStackProps) {
+          super(scope, id);
+          console.log(props.usedProp);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
   ],
 });

--- a/packages/eslint/src/__tests__/no-variable-construct-id.test.ts
+++ b/packages/eslint/src/__tests__/no-variable-construct-id.test.ts
@@ -294,6 +294,39 @@ ruleTester.run("no-variable-construct-id", noVariableConstructId, {
       }
       `,
     },
+    // WHEN: a Stack subclass is instantiated with a variable id at the top level
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+      class App extends Construct {}
+      class MyStack extends Stack {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      const app = new App();
+      new MyStack(app, 1 + "MyStack");
+      `,
+    },
+    // WHEN: a Stack subclass is instantiated with a variable id inside a Construct class
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+      class MyStack extends Stack {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new MyStack(this, id + "MyStack");
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     // WHEN: id is variable

--- a/packages/eslint/src/__tests__/prefer-grants-property.test.ts
+++ b/packages/eslint/src/__tests__/prefer-grants-property.test.ts
@@ -88,6 +88,25 @@ ruleTester.run("prefer-grants-property", preferGrantsProperty, {
       topic.grants.subscribe();
       `,
     },
+    // WHEN: receiver is a union of two Construct types
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      class Queue extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      declare const target: Topic | Queue;
+      target.grantPublish();
+      `,
+    },
   ],
   invalid: [
     // WHEN: class has grants property with Grants suffix and method exists

--- a/packages/eslint/src/__tests__/props-name-convention.test.ts
+++ b/packages/eslint/src/__tests__/props-name-convention.test.ts
@@ -78,6 +78,37 @@ ruleTester.run("props-name-convention", propsNameConvention, {
         }
       `,
     },
+    {
+      // WHEN: Class extends Stack (this rule applies to Construct classes only)
+      code: `
+        class Construct {}
+        class Stack extends Construct {}
+        interface WrongProps {
+          readonly bucket?: string;
+        }
+        class MyStack extends Stack {
+          constructor(scope: Construct, id: string, props: WrongProps) {
+            super(scope, id);
+          }
+        }
+      `,
+    },
+    {
+      // WHEN: Class extends a user-defined Stack base class (the whole Stack subtree is out of scope)
+      code: `
+        class Construct {}
+        class Stack extends Construct {}
+        class MyBaseStack extends Stack {}
+        interface WrongProps {
+          readonly bucket?: string;
+        }
+        class MyStack extends MyBaseStack {
+          constructor(scope: Construct, id: string, props: WrongProps) {
+            super(scope, id);
+          }
+        }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/eslint/src/__tests__/require-jsdoc.test.ts
+++ b/packages/eslint/src/__tests__/require-jsdoc.test.ts
@@ -146,5 +146,21 @@ ruleTester.run("require-jsdoc", requireJSDoc, {
         },
       ],
     },
+    {
+      // WHEN: Class extending Stack has an undocumented public property
+      code: `
+        class Construct {}
+        class Stack extends Construct {}
+        class MyStack extends Stack {
+          public bucketName: string;
+        }
+      `,
+      errors: [
+        {
+          messageId: "missingJSDoc",
+          data: { propertyName: "bucketName" },
+        },
+      ],
+    },
   ],
 });

--- a/packages/eslint/src/__tests__/require-passing-this.test.ts
+++ b/packages/eslint/src/__tests__/require-passing-this.test.ts
@@ -187,6 +187,51 @@ ruleTester.run("require-passing-this", requirePassingThis, {
       `,
       options: [{}],
     },
+    // WHEN: a Stack subclass is instantiated at the top level (no enclosing class)
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+      class App extends Construct {}
+      class SampleStack extends Stack {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      const app = new App();
+      new SampleStack(app, "Sample");
+      `,
+    },
+    // WHEN: App is instantiated with a props object at the top level
+    {
+      code: `
+      class Construct {}
+      class App extends Construct {
+        constructor(props: object) {
+          super();
+        }
+      }
+      const app = new App({});
+      `,
+    },
+    // WHEN: a Stack subclass is instantiated with 'scope' inside a Construct class
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+      class SampleStack extends Stack {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new SampleStack(scope, "Sample");
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     // WHEN: passing 'scope' variable

--- a/packages/eslint/src/core/cdk-construct/type-checker/is-app.ts
+++ b/packages/eslint/src/core/cdk-construct/type-checker/is-app.ts
@@ -1,0 +1,12 @@
+import { Type } from "typescript";
+
+import { isExtendsFromTargetSuperClass } from "../../ts-type/checker/is-extends-target-super-class";
+
+/**
+ * Check if the type is App or extends App
+ * @param type - The type to check
+ * @returns True if the type is App or extends App, otherwise false
+ */
+export const isAppType = (type: Type): boolean => {
+  return isExtendsFromTargetSuperClass(type, ["App"]);
+};

--- a/packages/eslint/src/core/cdk-construct/type-checker/is-construct-or-stack.ts
+++ b/packages/eslint/src/core/cdk-construct/type-checker/is-construct-or-stack.ts
@@ -12,6 +12,5 @@ export const isConstructOrStackType = (
   type: Type,
   ignoredClasses: readonly string[] = ["App", "Stage", "CfnOutput"] as const,
 ): boolean => {
-  if (ignoredClasses.includes(type.symbol?.name ?? "")) return false;
-  return isExtendsFromTargetSuperClass(type, ["Construct", "Stack"], isConstructOrStackType);
+  return isExtendsFromTargetSuperClass(type, ["Construct", "Stack"], ignoredClasses);
 };

--- a/packages/eslint/src/core/cdk-construct/type-checker/is-construct.ts
+++ b/packages/eslint/src/core/cdk-construct/type-checker/is-construct.ts
@@ -2,16 +2,33 @@ import { Type } from "typescript";
 
 import { isExtendsFromTargetSuperClass } from "../../ts-type/checker/is-extends-target-super-class";
 
+const DEFAULT_IGNORED_CLASSES = ["App", "Stage", "CfnOutput", "Stack"] as const;
+
 /**
- * Check if the type extends Construct
+ * Check if the type extends Construct, ignoring the given classes themselves but not their subclasses
  * @param type - The type to check
  * @param ignoredClasses - Classes that inherit from Construct Class but do not want to be treated as Construct Class
  * @returns True if the type extends Construct, otherwise false
  */
 export const isConstructType = (
   type: Type,
-  ignoredClasses: readonly string[] = ["App", "Stage", "CfnOutput", "Stack"] as const,
+  ignoredClasses: readonly string[] = DEFAULT_IGNORED_CLASSES,
 ): boolean => {
   if (ignoredClasses.includes(type.symbol?.name ?? "")) return false;
-  return isExtendsFromTargetSuperClass(type, ["Construct"], isConstructType);
+  return isExtendsFromTargetSuperClass(type, ["Construct"]);
+};
+
+/**
+ * Check if the type extends Construct, ignoring the given classes together with every class derived from them.
+ * Used where instantiating an ignored class is idiomatic (e.g. `new SampleStack(app, "Sample")`),
+ * so its subclasses must stay out of scope as well.
+ * @param type - The type to check
+ * @param ignoredClasses - Classes whose whole inheritance subtree is not treated as Construct Class
+ * @returns True if the type extends Construct outside the ignored subtrees, otherwise false
+ */
+export const isConstructTypeIgnoringSubclasses = (
+  type: Type,
+  ignoredClasses: readonly string[] = DEFAULT_IGNORED_CLASSES,
+): boolean => {
+  return isExtendsFromTargetSuperClass(type, ["Construct"], ignoredClasses);
 };

--- a/packages/eslint/src/core/cdk-construct/type-checker/is-resource.ts
+++ b/packages/eslint/src/core/cdk-construct/type-checker/is-resource.ts
@@ -12,6 +12,5 @@ export const isResourceType = (
   type: Type,
   ignoredClasses: readonly string[] = [], // App, Stage, CfnOutput, Stack are not extended Resource, so no need to ignore them
 ): boolean => {
-  if (ignoredClasses.includes(type.symbol?.name ?? "")) return false;
-  return isExtendsFromTargetSuperClass(type, ["Resource"], isResourceType);
+  return isExtendsFromTargetSuperClass(type, ["Resource"], ignoredClasses);
 };

--- a/packages/eslint/src/core/ts-type/checker/is-extends-target-super-class.ts
+++ b/packages/eslint/src/core/ts-type/checker/is-extends-target-super-class.ts
@@ -4,14 +4,18 @@ import { Type } from "typescript";
  * Check if the type extends target super class
  * @param type - The type to check
  * @param targetSuperClasses - The target super classes
+ * @param ignoredClasses - Class names that stop the walk, matched at every level of the base chain
  * @returns True if the type extends target super class, otherwise false
  */
 export const isExtendsFromTargetSuperClass = (
   type: Type,
-  targetSuperClasses: string[],
-  typeCheckFunction: (type: Type) => boolean,
+  targetSuperClasses: readonly string[],
+  ignoredClasses: readonly string[] = [],
 ): boolean => {
   if (!type.symbol) return false;
+
+  // NOTE: An ignored class is not a match, and neither is anything reached through it
+  if (ignoredClasses.includes(type.symbol.name)) return false;
 
   // NOTE: Check if the current type ends in target super class
   if (targetSuperClasses.some((suffix) => type.symbol.name === suffix)) {
@@ -20,5 +24,7 @@ export const isExtendsFromTargetSuperClass = (
 
   // NOTE: Check the base type
   const baseTypes = type.getBaseTypes() ?? [];
-  return baseTypes.some((baseType) => typeCheckFunction(baseType));
+  return baseTypes.some((baseType) =>
+    isExtendsFromTargetSuperClass(baseType, targetSuperClasses, ignoredClasses),
+  );
 };

--- a/packages/eslint/src/rules/construct-constructor-property.ts
+++ b/packages/eslint/src/rules/construct-constructor-property.ts
@@ -8,6 +8,7 @@ import {
 
 import { findConstructor } from "../core/ast-node/finder/constructor";
 import { findConstructorParamIdentifier } from "../core/ast-node/finder/constructor-param-identifier";
+import { isAppType } from "../core/cdk-construct/type-checker/is-app";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
@@ -51,7 +52,9 @@ export const constructConstructorProperty = createRule({
     return {
       ClassDeclaration(node) {
         const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructType(type)) return;
+        // NOTE: App and its subclasses take `(props)` instead of `(scope, id)`,
+        // so they can never satisfy this rule
+        if (!isConstructType(type) || isAppType(type)) return;
 
         const constructor = findConstructor(node);
         if (!constructor) return;
@@ -86,7 +89,8 @@ const checkNumOfConstructorProperty = (
 };
 
 /**
- * Checks if the first parameter is named "scope" and of type Construct
+ * Checks if the first parameter is named "scope" and of type Construct.
+ * Every Construct is a valid scope, App / Stage / Stack / CfnOutput included, so no class is ignored.
  */
 const checkFirstParamIsScope = (
   firstParam: ConstructorProperties[0],
@@ -99,7 +103,7 @@ const checkFirstParamIsScope = (
       node: firstParam,
       messageId: "invalidConstructorProperty",
     });
-  } else if (!isConstructType(parserServices.getTypeAtLocation(binding))) {
+  } else if (!isConstructType(parserServices.getTypeAtLocation(binding), [])) {
     context.report({
       node: firstParam,
       messageId: "invalidConstructorType",

--- a/packages/eslint/src/rules/no-parent-name-construct-id-match.ts
+++ b/packages/eslint/src/rules/no-parent-name-construct-id-match.ts
@@ -3,7 +3,7 @@ import { ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
 import { findConstructIdString } from "../core/ast-node/finder/construct-id-string";
 import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isInsideConstructorOrMethod } from "../core/ast-node/finder/enclosing-method";
-import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
 import { createRule } from "../shared/create-rule";
@@ -57,7 +57,7 @@ export const noParentNameConstructIdMatch = createRule({
         if (node.arguments.length < 2) return;
 
         const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructType(type)) return;
+        if (!isConstructTypeIgnoringSubclasses(type)) return;
 
         // NOTE: nested closures do not have a stable "parent class" relationship
         if (!isInsideConstructorOrMethod(node)) return;

--- a/packages/eslint/src/rules/no-variable-construct-id.ts
+++ b/packages/eslint/src/rules/no-variable-construct-id.ts
@@ -1,7 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils, TSESLint, TSESTree } from "@typescript-eslint/utils";
 
 import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
-import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { createRule } from "../shared/create-rule";
@@ -33,7 +33,7 @@ export const noVariableConstructId = createRule({
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
 
-        if (!isConstructType(type) || node.arguments.length < 2) return;
+        if (!isConstructTypeIgnoringSubclasses(type) || node.arguments.length < 2) return;
 
         // NOTE: Skip when inside a class that is not Construct/Stack
         const enclosingClass = findEnclosingClass(node);

--- a/packages/eslint/src/rules/prefer-grants-property.ts
+++ b/packages/eslint/src/rules/prefer-grants-property.ts
@@ -1,6 +1,6 @@
 import { AST_NODE_TYPES, ESLintUtils, TSESTree } from "@typescript-eslint/utils";
 
-import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
 export const preferGrantsProperty = createRule({
@@ -36,7 +36,7 @@ export const preferGrantsProperty = createRule({
         const objectNode = node.callee.object;
         const tsNode = parserServices.esTreeNodeToTSNodeMap.get(objectNode);
         const type = checker.getTypeAtLocation(tsNode);
-        if (!isConstructType(type)) return;
+        if (!isConstructTypeIgnoringSubclasses(type)) return;
 
         const grantsProperty = type.getProperty("grants");
         if (!grantsProperty) return;

--- a/packages/eslint/src/rules/prevent-construct-id-collision.ts
+++ b/packages/eslint/src/rules/prevent-construct-id-collision.ts
@@ -2,7 +2,7 @@ import { AST_NODE_TYPES, ESLintUtils, TSESTree } from "@typescript-eslint/utils"
 
 import { isDeclaredInEnclosingBlocks } from "../core/ast-node/finder/declared-in-enclosing-blocks";
 import { findEnclosingLoopBody } from "../core/ast-node/finder/enclosing-loop-body";
-import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { createRule } from "../shared/create-rule";
 
@@ -32,7 +32,7 @@ export const preventConstructIdCollision = createRule({
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
 
-        if (!isConstructType(type) || node.arguments.length < 2) return;
+        if (!isConstructTypeIgnoringSubclasses(type) || node.arguments.length < 2) return;
 
         const calleeType = parserServices.getTypeAtLocation(node.callee);
         const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);

--- a/packages/eslint/src/rules/props-name-convention.ts
+++ b/packages/eslint/src/rules/props-name-convention.ts
@@ -2,7 +2,7 @@ import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 import { findConstructor } from "../core/ast-node/finder/constructor";
 import { findConstructorParamIdentifier } from "../core/ast-node/finder/constructor-param-identifier";
-import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -31,7 +31,7 @@ export const propsNameConvention = createRule({
         if (!node.id || !node.superClass) return;
 
         const type = parserServices.getTypeAtLocation(node.superClass);
-        if (!isConstructType(type)) return;
+        if (!isConstructTypeIgnoringSubclasses(type)) return;
 
         // NOTE: check constructor parameter
         const constructor = findConstructor(node);

--- a/packages/eslint/src/rules/require-passing-this.ts
+++ b/packages/eslint/src/rules/require-passing-this.ts
@@ -1,7 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils, TSESLint } from "@typescript-eslint/utils";
 
 import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
-import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { createRule } from "../shared/create-rule";
@@ -55,7 +55,7 @@ export const requirePassingThis = createRule({
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
 
-        if (!isConstructType(type) || !node.arguments.length) return;
+        if (!isConstructTypeIgnoringSubclasses(type) || !node.arguments.length) return;
 
         // NOTE: Only flag when inside a Construct/Stack class where `this` is available
         const enclosingClass = findEnclosingClass(node);

--- a/packages/oxlint/src/__tests__/construct-constructor-property.test.ts
+++ b/packages/oxlint/src/__tests__/construct-constructor-property.test.ts
@@ -121,6 +121,48 @@ ruleTester.run("construct-constructor-property", constructConstructorProperty, {
       }
       `,
     },
+    {
+      code: `
+      class Construct {}
+      interface AppProps {}
+      class App extends Construct {
+        constructor(props?: AppProps) {
+          super();
+        }
+      }
+
+      export class MyApp extends App {
+        constructor(props?: AppProps) {
+          super(props);
+        }
+      }
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: Stack, id: string) {
+          super(scope, id);
+        }
+      }
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+      class MyStack extends Stack {}
+
+      export class MyConstruct extends Construct {
+        constructor(scope: MyStack, id: string) {
+          super(scope, id);
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {
@@ -252,6 +294,22 @@ ruleTester.run("construct-constructor-property", constructConstructorProperty, {
       `,
       errors: [
         { messageId: "invalidConstructorProperty" },
+        { messageId: "invalidConstructorProperty" },
+        { messageId: "invalidConstructorProperty" },
+      ],
+    },
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+
+      export class BadStack extends Stack {
+        constructor(myScope: Construct, myId: string) {
+          super(myScope, myId);
+        }
+      }
+      `,
+      errors: [
         { messageId: "invalidConstructorProperty" },
         { messageId: "invalidConstructorProperty" },
       ],

--- a/packages/oxlint/src/__tests__/no-unused-props.test.ts
+++ b/packages/oxlint/src/__tests__/no-unused-props.test.ts
@@ -1402,5 +1402,25 @@ ruleTester.run("no-unused-props", noUnusedProps, {
       `,
       errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
     },
+    {
+      name: "Class extending Stack: some properties are unused",
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+
+      interface MyStackProps {
+        usedProp: string;
+        unusedProp: string;
+      }
+
+      export class MyStack extends Stack {
+        constructor(scope: Construct, id: string, props: MyStackProps) {
+          super(scope, id);
+          console.log(props.usedProp);
+        }
+      }
+      `,
+      errors: [{ messageId: "unusedProp", data: { propName: "unusedProp" } }],
+    },
   ],
 });

--- a/packages/oxlint/src/__tests__/no-variable-construct-id.test.ts
+++ b/packages/oxlint/src/__tests__/no-variable-construct-id.test.ts
@@ -271,6 +271,37 @@ ruleTester.run("no-variable-construct-id", noVariableConstructId, {
       }
       `,
     },
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+      class App extends Construct {}
+      class MyStack extends Stack {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      const app = new App();
+      new MyStack(app, 1 + "MyStack");
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+      class MyStack extends Stack {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new MyStack(this, id + "MyStack");
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/oxlint/src/__tests__/prefer-grants-property.test.ts
+++ b/packages/oxlint/src/__tests__/prefer-grants-property.test.ts
@@ -76,6 +76,24 @@ ruleTester.run("prefer-grants-property", preferGrantsProperty, {
       topic.grants.subscribe();
       `,
     },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      class Queue extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      declare const target: Topic | Queue;
+      target.grantPublish();
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/oxlint/src/__tests__/props-name-convention.test.ts
+++ b/packages/oxlint/src/__tests__/props-name-convention.test.ts
@@ -72,6 +72,37 @@ ruleTester.run("props-name-convention", propsNameConvention, {
         }
       `,
     },
+    {
+      // WHEN: Class extends Stack (this rule applies to Construct classes only)
+      code: `
+        class Construct {}
+        class Stack extends Construct {}
+        interface WrongProps {
+          readonly bucket?: string;
+        }
+        class MyStack extends Stack {
+          constructor(scope: Construct, id: string, props: WrongProps) {
+            super(scope, id);
+          }
+        }
+      `,
+    },
+    {
+      // WHEN: Class extends a user-defined Stack base class (the whole Stack subtree is out of scope)
+      code: `
+        class Construct {}
+        class Stack extends Construct {}
+        class MyBaseStack extends Stack {}
+        interface WrongProps {
+          readonly bucket?: string;
+        }
+        class MyStack extends MyBaseStack {
+          constructor(scope: Construct, id: string, props: WrongProps) {
+            super(scope, id);
+          }
+        }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/oxlint/src/__tests__/require-jsdoc.test.ts
+++ b/packages/oxlint/src/__tests__/require-jsdoc.test.ts
@@ -140,5 +140,21 @@ ruleTester.run("require-jsdoc", requireJSDoc, {
         },
       ],
     },
+    {
+      // WHEN: Class extending Stack has an undocumented public property
+      code: `
+        class Construct {}
+        class Stack extends Construct {}
+        class MyStack extends Stack {
+          public bucketName: string;
+        }
+      `,
+      errors: [
+        {
+          messageId: "missingJSDoc",
+          data: { propertyName: "bucketName" },
+        },
+      ],
+    },
   ],
 });

--- a/packages/oxlint/src/__tests__/require-passing-this.test.ts
+++ b/packages/oxlint/src/__tests__/require-passing-this.test.ts
@@ -148,6 +148,48 @@ ruleTester.run("require-passing-this", requirePassingThis, {
       `,
       options: [{}],
     },
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+      class App extends Construct {}
+      class SampleStack extends Stack {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      const app = new App();
+      new SampleStack(app, "Sample");
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      class App extends Construct {
+        constructor(props: object) {
+          super();
+        }
+      }
+      const app = new App({});
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      class Stack extends Construct {}
+      class SampleStack extends Stack {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new SampleStack(scope, "Sample");
+        }
+      }
+      `,
+    },
   ],
   invalid: [
     {

--- a/packages/oxlint/src/core/cdk-construct/type-checker/is-app.ts
+++ b/packages/oxlint/src/core/cdk-construct/type-checker/is-app.ts
@@ -1,0 +1,13 @@
+import type { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
+
+import { isExtendsFromTargetSuperClass } from "../../ts-type/checker/is-extends-target-super-class";
+
+/**
+ * Check if the type is App or extends App
+ * @param type - The type to check
+ * @param checker - The corsa-oxlint type checker
+ * @returns True if the type is App or extends App, otherwise false
+ */
+export const isAppType = (type: CorsaType | undefined, checker: CorsaTypeCheckerShape): boolean => {
+  return isExtendsFromTargetSuperClass(type, checker, ["App"]);
+};

--- a/packages/oxlint/src/core/cdk-construct/type-checker/is-construct.ts
+++ b/packages/oxlint/src/core/cdk-construct/type-checker/is-construct.ts
@@ -2,8 +2,10 @@ import type { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
 
 import { isExtendsFromTargetSuperClass } from "../../ts-type/checker/is-extends-target-super-class";
 
+const DEFAULT_IGNORED_CLASSES = ["App", "Stage", "CfnOutput", "Stack"] as const;
+
 /**
- * Check if the type extends Construct
+ * Check if the type extends Construct, ignoring the given classes themselves but not their subclasses
  * @param type - The type to check
  * @param checker - The corsa-oxlint type checker
  * @param ignoredClasses - Classes that inherit from Construct but should not be treated as Construct
@@ -12,7 +14,26 @@ import { isExtendsFromTargetSuperClass } from "../../ts-type/checker/is-extends-
 export const isConstructType = (
   type: CorsaType | undefined,
   checker: CorsaTypeCheckerShape,
-  ignoredClasses: readonly string[] = ["App", "Stage", "CfnOutput", "Stack"] as const,
+  ignoredClasses: readonly string[] = DEFAULT_IGNORED_CLASSES,
+): boolean => {
+  if (!type) return false;
+  if (ignoredClasses.includes(checker.getSymbolOfType(type)?.name ?? "")) return false;
+  return isExtendsFromTargetSuperClass(type, checker, ["Construct"]);
+};
+
+/**
+ * Check if the type extends Construct, ignoring the given classes together with every class derived from them.
+ * Used where instantiating an ignored class is idiomatic (e.g. `new SampleStack(app, "Sample")`),
+ * so its subclasses must stay out of scope as well.
+ * @param type - The type to check
+ * @param checker - The corsa-oxlint type checker
+ * @param ignoredClasses - Classes whose whole inheritance subtree is not treated as Construct
+ * @returns True if the type extends Construct outside the ignored subtrees, otherwise false
+ */
+export const isConstructTypeIgnoringSubclasses = (
+  type: CorsaType | undefined,
+  checker: CorsaTypeCheckerShape,
+  ignoredClasses: readonly string[] = DEFAULT_IGNORED_CLASSES,
 ): boolean => {
   return isExtendsFromTargetSuperClass(type, checker, ["Construct"], ignoredClasses);
 };

--- a/packages/oxlint/src/core/ts-type/checker/is-extends-target-super-class.ts
+++ b/packages/oxlint/src/core/ts-type/checker/is-extends-target-super-class.ts
@@ -5,18 +5,24 @@ import type { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
  * @param type - The type to check
  * @param checker - The corsa-oxlint type checker
  * @param targetSuperClasses - Super class names to match
- * @param ignoredClasses - Class names to treat as non-match even if they would match
+ * @param ignoredClasses - Class names that stop the walk, matched at every level of the base chain
  * @returns True if the type extends any of the target super classes
  */
 export const isExtendsFromTargetSuperClass = (
   type: CorsaType | undefined,
   checker: CorsaTypeCheckerShape,
   targetSuperClasses: readonly string[],
-  ignoredClasses: readonly string[],
+  ignoredClasses: readonly string[] = [],
 ): boolean => {
   if (!type) return false;
+
+  // NOTE: A union / intersection type is not a class of its own, so it never extends a super class.
+  // Callers that want to look inside it use findTypeOfCdkConstruct instead.
+  if (checker.isUnionType(type) || checker.isIntersectionType(type)) return false;
+
   const name = checker.getSymbolOfType(type)?.name ?? "";
 
+  // NOTE: An ignored class is not a match, and neither is anything reached through it
   if (ignoredClasses.includes(name)) return false;
   if (targetSuperClasses.includes(name)) return true;
 

--- a/packages/oxlint/src/rules/construct-constructor-property.ts
+++ b/packages/oxlint/src/rules/construct-constructor-property.ts
@@ -4,6 +4,7 @@ import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findConstructor } from "../core/ast-node/finder/constructor";
 import { findConstructorParamIdentifier } from "../core/ast-node/finder/constructor-param-identifier";
+import { isAppType } from "../core/cdk-construct/type-checker/is-app";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
@@ -46,7 +47,9 @@ export const constructConstructorProperty = createRule({
     return {
       ClassDeclaration(node) {
         const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructType(type, checker)) return;
+        // NOTE: App and its subclasses take `(props)` instead of `(scope, id)`,
+        // so they can never satisfy this rule
+        if (!isConstructType(type, checker) || isAppType(type, checker)) return;
 
         const constructor = findConstructor(node);
         if (!constructor) return;
@@ -81,7 +84,8 @@ const checkNumOfConstructorProperty = (
 };
 
 /**
- * Checks if the first parameter is named "scope" and of type Construct
+ * Checks if the first parameter is named "scope" and of type Construct.
+ * Every Construct is a valid scope, App / Stage / Stack / CfnOutput included, so no class is ignored.
  */
 const checkFirstParamIsScope = (
   firstParam: ConstructorProperties[0],
@@ -98,6 +102,7 @@ const checkFirstParamIsScope = (
     !isConstructType(
       parserServices.getTypeAtLocation(binding),
       parserServices.program.getTypeChecker(),
+      [],
     )
   ) {
     context.report({

--- a/packages/oxlint/src/rules/no-parent-name-construct-id-match.ts
+++ b/packages/oxlint/src/rules/no-parent-name-construct-id-match.ts
@@ -5,7 +5,7 @@ import { ESLintUtils } from "corsa-oxlint";
 import { findConstructIdString } from "../core/ast-node/finder/construct-id-string";
 import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isInsideConstructorOrMethod } from "../core/ast-node/finder/enclosing-method";
-import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
 import { createRule } from "../shared/create-rule";
@@ -57,7 +57,7 @@ export const noParentNameConstructIdMatch = createRule({
         if (node.arguments.length < 2) return;
 
         const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructType(type, checker)) return;
+        if (!isConstructTypeIgnoringSubclasses(type, checker)) return;
 
         // NOTE: nested closures do not have a stable "parent class" relationship
         if (!isInsideConstructorOrMethod(node)) return;

--- a/packages/oxlint/src/rules/no-variable-construct-id.ts
+++ b/packages/oxlint/src/rules/no-variable-construct-id.ts
@@ -3,7 +3,7 @@ import type { ESTree, RuleContext } from "corsa-oxlint";
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
-import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { createRule } from "../shared/create-rule";
@@ -32,7 +32,7 @@ export const noVariableConstructId = createRule({
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
 
-        if (!isConstructType(type, checker) || node.arguments.length < 2) return;
+        if (!isConstructTypeIgnoringSubclasses(type, checker) || node.arguments.length < 2) return;
 
         // NOTE: Skip when inside a class that is not Construct/Stack
         const enclosingClass = findEnclosingClass(node);

--- a/packages/oxlint/src/rules/prefer-grants-property.ts
+++ b/packages/oxlint/src/rules/prefer-grants-property.ts
@@ -1,6 +1,6 @@
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
-import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
 export const preferGrantsProperty = createRule({
@@ -36,7 +36,7 @@ export const preferGrantsProperty = createRule({
 
         const objectNode = node.callee.object;
         const type = parserServices.getTypeAtLocation(objectNode);
-        if (!type || !isConstructType(type, checker)) return;
+        if (!type || !isConstructTypeIgnoringSubclasses(type, checker)) return;
 
         const grantsProperty = checker.getPropertiesOfType(type).find((s) => s.name === "grants");
         if (!grantsProperty) return;

--- a/packages/oxlint/src/rules/prevent-construct-id-collision.ts
+++ b/packages/oxlint/src/rules/prevent-construct-id-collision.ts
@@ -4,7 +4,7 @@ import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { isDeclaredInEnclosingBlocks } from "../core/ast-node/finder/declared-in-enclosing-blocks";
 import { findEnclosingLoopBody } from "../core/ast-node/finder/enclosing-loop-body";
-import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { createRule } from "../shared/create-rule";
 
@@ -35,7 +35,7 @@ export const preventConstructIdCollision = createRule({
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
 
-        if (!isConstructType(type, checker) || node.arguments.length < 2) return;
+        if (!isConstructTypeIgnoringSubclasses(type, checker) || node.arguments.length < 2) return;
 
         const calleeType = parserServices.getTypeAtLocation(node.callee);
         const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);

--- a/packages/oxlint/src/rules/props-name-convention.ts
+++ b/packages/oxlint/src/rules/props-name-convention.ts
@@ -2,7 +2,7 @@ import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findConstructor } from "../core/ast-node/finder/constructor";
 import { findConstructorParamIdentifier } from "../core/ast-node/finder/constructor-param-identifier";
-import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -31,7 +31,7 @@ export const propsNameConvention = createRule({
         if (!node.id || !node.superClass) return;
 
         const type = parserServices.getTypeAtLocation(node.superClass);
-        if (!isConstructType(type, checker)) return;
+        if (!isConstructTypeIgnoringSubclasses(type, checker)) return;
 
         // NOTE: check constructor parameter
         const constructor = findConstructor(node);

--- a/packages/oxlint/src/rules/require-passing-this.ts
+++ b/packages/oxlint/src/rules/require-passing-this.ts
@@ -1,7 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
-import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
 import { createRule } from "../shared/create-rule";
@@ -52,7 +52,7 @@ export const requirePassingThis = createRule({
       NewExpression(node) {
         const type = parserServices.getTypeAtLocation(node);
 
-        if (!isConstructType(type, checker) || !node.arguments.length) return;
+        if (!isConstructTypeIgnoringSubclasses(type, checker) || !node.arguments.length) return;
 
         // NOTE: Only flag when inside a Construct/Stack class where `this` is available
         const enclosingClass = findEnclosingClass(node);


### PR DESCRIPTION
### Issue # (if applicable)

Closes #570.

### Reason for this change

`isConstructType` applied its ignore list (`App`, `Stage`, `CfnOutput`, `Stack`) at every level of the base-type chain, so a `class MyStack extends Stack` was never treated as a Construct. `no-unused-props`, `construct-constructor-property` and `require-jsdoc` skipped Stack subclasses entirely, and `construct-constructor-property` reported `constructor(scope: Stack, id: string)` as an invalid scope type.

### Description of changes

- Split the ignore list into two tiers. `isConstructType` applies it to the checked type only; the new `isConstructTypeIgnoringSubclasses` applies it to the whole base-type chain as before. Rules that inspect a class declaration use the former, rules that inspect a `new` expression or a `superClass` use the latter.
- `no-unused-props` / `construct-constructor-property` / `require-jsdoc` now apply to `class X extends Stack`, and likewise to Stage / CfnOutput subclasses.
- `construct-constructor-property` keeps the App subtree out of scope (`isAppType`). App's constructor takes `(props)` instead of `(scope, id)`, so no App subclass can satisfy the rule.
- `construct-constructor-property` no longer applies the ignore list to the type of the `scope` parameter. Every Construct is a valid scope, so `scope: Stack` / `scope: App` / `scope: Stage` / `scope: CfnOutput` are accepted. `Stack` itself stays in the ignore list, so the top-level-only change alone would not have fixed this call site; only here is the list emptied.
- The oxlint base-chain walker no longer treats union / intersection types as Constructs, matching eslint, which bails out on `!type.symbol`. Until now only oxlint reported a receiver such as `declare const t: Topic | Queue; t.grantPublish()` under `prefer-grants-property`; closing the gap in the PR that touches this function seemed right. `no-construct-in-interface` / `no-construct-in-public-property-of-construct` walk unions themselves via `findTypeOfCdkConstruct` and are unaffected (all 760 cases pass).

Behavior preserved on purpose:

- `no-variable-construct-id` / `no-parent-name-construct-id-match` / `prevent-construct-id-collision` / `require-passing-this` (`new` expressions), the receiver check of `prefer-grants-property` and the `superClass` check of `props-name-convention` keep using the subtree tier, so the whole Stack / App / Stage / CfnOutput subtree stays out of scope as before. This keeps `examples/lib/no-variable-construct-id.ts` (`new MyStack(app, 1 + "MyStack")`, marked `// ✅ Can use variable stack ID`) and the documented Construct-only scope of `props-name-convention` intact.
- `isConstructOrStackType` / `isResourceType`: no observable change. A caller-supplied ignore list now propagates down the chain, but every existing call site uses the default arguments, so the output is identical to `main`.

Known and pre-existing on `main`, not addressed here: eslint's `props-name-convention` fires only on a direct `extends Construct`, because the `superClass` identifier resolves to the class constructor type, which has no base types, while oxlint walks the chain (`class X extends MyBaseConstruct` is reported by oxlint only; verified on `main`).

### Description of how you validated changes

- Added 28 test cases across both packages (14 each): Stack subclasses under the three class-level rules, `scope: Stack` / `scope: MyStack`, the App subclass exemption, top-level `new MyStack(app, 1 + "MyStack")`, a Stack subclass created inside a Construct class, the Stack subtree exemption of `props-name-convention`, and the `Topic | Queue` receiver. The cases tied to a behavior change fail on the previous code; the rest are regression guards for #78 / #93, the `examples` fixture and the preserved behavior listed above.
- `vp check` and `vp test --run` (760/760) pass; `vp run -r pack && bash scripts/integration-test.sh` prints SUCCESS three times (43/43).
- Dependencies used: corsa-oxlint 1.13.1 / oxlint 1.81.0 / TypeScript 7.0.2 (oxlint), ESLint 10.9.1 / TypeScript 6.0.3 (eslint).

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_

