### PR TITLE
fix: report grant* calls on optional Construct receivers in prefer-grants-property

### DIFF
--- a/packages/eslint/src/__tests__/prefer-grants-property.test.ts
+++ b/packages/eslint/src/__tests__/prefer-grants-property.test.ts
@@ -107,6 +107,21 @@ ruleTester.run("prefer-grants-property", preferGrantsProperty, {
       target.grantPublish();
       `,
     },
+    // WHEN: receiver is a union of a Construct and a non-Construct type
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      declare const topic: Topic | string;
+      topic.grantPublish();
+      `,
+    },
   ],
   invalid: [
     // WHEN: class has grants property with Grants suffix and method exists
@@ -137,6 +152,84 @@ ruleTester.run("prefer-grants-property", preferGrantsProperty, {
         grantPublish() {}
       }
       const topic = new Topic();
+      topic.grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    // WHEN: receiver is a required Construct-typed prop
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      interface MyConstructProps {
+        readonly topic: Topic;
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          props.topic.grantPublish();
+        }
+      }
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    // WHEN: receiver is an optional Construct-typed prop accessed with optional chaining
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      interface MyConstructProps {
+        readonly topic?: Topic;
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          props.topic?.grantPublish();
+        }
+      }
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    // WHEN: receiver is a union with void
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      declare const topic: Topic | void;
+      topic.grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    // WHEN: receiver is a union with null
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      declare const topic: Topic | null;
       topic.grantPublish();
       `,
       errors: [{ messageId: "useGrantsProperty" }],

--- a/packages/eslint/src/rules/prefer-grants-property.ts
+++ b/packages/eslint/src/rules/prefer-grants-property.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils, TSESTree } from "@typescript-eslint/utils";
 
 import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
+import { findNonNullableType } from "../core/ts-type/finder/non-nullable-type";
 import { createRule } from "../shared/create-rule";
 
 export const preferGrantsProperty = createRule({
@@ -35,7 +36,9 @@ export const preferGrantsProperty = createRule({
 
         const objectNode = node.callee.object;
         const tsNode = parserServices.esTreeNodeToTSNodeMap.get(objectNode);
-        const type = checker.getTypeAtLocation(tsNode);
+        // NOTE: An optional receiver such as `props.topic?.grantPublish()` is typed
+        // `Topic | undefined`, so strip the nullish members before inspecting the Construct.
+        const type = findNonNullableType(checker.getTypeAtLocation(tsNode), checker);
         if (!isConstructTypeIgnoringSubclasses(type)) return;
 
         const grantsProperty = type.getProperty("grants");

--- a/packages/oxlint/src/__tests__/prefer-grants-property.test.ts
+++ b/packages/oxlint/src/__tests__/prefer-grants-property.test.ts
@@ -94,6 +94,20 @@ ruleTester.run("prefer-grants-property", preferGrantsProperty, {
       target.grantPublish();
       `,
     },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      declare const topic: Topic | string;
+      topic.grantPublish();
+      `,
+    },
   ],
   invalid: [
     {
@@ -122,6 +136,80 @@ ruleTester.run("prefer-grants-property", preferGrantsProperty, {
         grantPublish() {}
       }
       const topic = new Topic();
+      topic.grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      interface MyConstructProps {
+        readonly topic: Topic;
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          props.topic.grantPublish();
+        }
+      }
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      interface MyConstructProps {
+        readonly topic?: Topic;
+      }
+      class MyConstruct extends Construct {
+        constructor(scope: Construct, id: string, props: MyConstructProps) {
+          super(scope, id);
+          props.topic?.grantPublish();
+        }
+      }
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      declare const topic: Topic | void;
+      topic.grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      declare const topic: Topic | null;
       topic.grantPublish();
       `,
       errors: [{ messageId: "useGrantsProperty" }],

--- a/packages/oxlint/src/rules/prefer-grants-property.ts
+++ b/packages/oxlint/src/rules/prefer-grants-property.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
+import { findNonNullableType } from "../core/ts-type/finder/non-nullable-type";
 import { createRule } from "../shared/create-rule";
 
 export const preferGrantsProperty = createRule({
@@ -35,8 +36,13 @@ export const preferGrantsProperty = createRule({
         if (!methodName.startsWith("grant")) return;
 
         const objectNode = node.callee.object;
-        const type = parserServices.getTypeAtLocation(objectNode);
-        if (!type || !isConstructTypeIgnoringSubclasses(type, checker)) return;
+        const receiverType = parserServices.getTypeAtLocation(objectNode);
+        if (!receiverType) return;
+
+        // NOTE: An optional receiver such as `props.topic?.grantPublish()` is typed
+        // `Topic | undefined`, so strip the nullish members before inspecting the Construct.
+        const type = findNonNullableType(receiverType, checker);
+        if (!isConstructTypeIgnoringSubclasses(type, checker)) return;
 
         const grantsProperty = checker.getPropertiesOfType(type).find((s) => s.name === "grants");
         if (!grantsProperty) return;


### PR DESCRIPTION
### Issue # (if applicable)

Closes #574.

### Reason for this change

`prefer-grants-property` resolved the receiver type of a `grant*` call as-is, so an optional receiver such as `props.topic?.grantPublish()`, typed `Topic | undefined`, was never recognized as a Construct and the call was not reported.

### Description of changes

- Strip `undefined` / `null` / `void` from the receiver type before the Construct check, so optional receivers such as `props.topic?.grantPublish()` are reported. This reuses the shared `findNonNullableType` finder that landed with #584; the two packages' copies of that file are byte-identical and this PR only imports it.
- Add receiver tests to both packages: optional, required, `void`, `null`, and a union with a non-Construct member.

Design decisions:

- The nullish members are stripped at the call site rather than inside `isConstructType`. After the check the rule looks up the `grants` property on the same type; on the union, `getProperty("grants")` / `getPropertiesOfType` return nothing and the call could not be reported anyway, so the stripped type has to be the one used downstream.
- A union that keeps two or more non-nullish members (`Topic | string`) is not reported. Since #585 both packages reach that outcome the same way: the base-chain walker bails out on union / intersection types, so `isConstructTypeIgnoringSubclasses(Topic | string)` is false in eslint and oxlint alike. `grants` is not guaranteed on every member and TypeScript itself rejects a `grant*` call on such a receiver, so this seems right. Say so if reporting is preferred.

### Merge notes

- #587: `packages/oxlint/src/rules/prefer-grants-property.ts` and both test files conflict. Whichever lands second must apply `findNonNullableType` to each candidate inside `hasGrantsMethod` as well.

### Description of how you validated changes

- The optional-receiver and `Topic | void` cases fail on the previous code; the required receiver and `Topic | string` cases pass before and after and act as regression guards.
- `vp check` and `vp test --run` (770/770) pass; `vp run -r pack && bash scripts/integration-test.sh` prints SUCCESS three times (43/43).
- Dependencies used: corsa-oxlint 1.13.1 / oxlint 1.81.0 / TypeScript 7.0.2 (oxlint), ESLint 10.9.1 / TypeScript 6.0.3 (eslint).

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
