### PR TITLE
fix: skip unresolvable computed member and overloaded call receivers in prefer-grants-property

### DIFF
--- a/packages/eslint/src/__tests__/prefer-grants-property.test.ts
+++ b/packages/eslint/src/__tests__/prefer-grants-property.test.ts
@@ -122,6 +122,85 @@ ruleTester.run("prefer-grants-property", preferGrantsProperty, {
       topic.grantPublish();
       `,
     },
+    // WHEN: the call receiver returns a type without a grants property
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Plain {
+        grantPublish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+        plain(): Plain {
+          return new Plain();
+        }
+      }
+      const topic = new Topic();
+      topic.plain().grantPublish();
+      `,
+    },
+    // WHEN: the call receiver indexes a callee out of a callable object
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Plain {
+        grantPublish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      const fn = Object.assign((): Topic => new Topic(), { k: (): Plain => new Plain() });
+      fn["k"]().grantPublish();
+      `,
+    },
+    // WHEN: the receiver indexes a Construct whose index signature yields a non-Construct
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Registry extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      interface Registry {
+        [key: string]: any;
+      }
+      declare const registry: Registry;
+      registry["x"].grantPublish();
+      `,
+    },
+    // WHEN: an overloaded callee resolves to a return type without a grants property
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      class Plain {
+        grantPublish() {}
+      }
+      function ov(value: "b"): Plain;
+      function ov(value: "a"): Topic;
+      function ov(value: unknown): Topic | Plain {
+        return value === "a" ? new Topic() : new Plain();
+      }
+      ov("b").grantPublish();
+      `,
+    },
   ],
   invalid: [
     // WHEN: class has grants property with Grants suffix and method exists
@@ -231,6 +310,140 @@ ruleTester.run("prefer-grants-property", preferGrantsProperty, {
       }
       declare const topic: Topic | null;
       topic.grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    // WHEN: the receiver is a method call
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      class MyConstruct extends Construct {
+        run() {
+          this.helper().grantPublish();
+        }
+        helper(): Topic {
+          return new Topic();
+        }
+      }
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    // WHEN: the receiver is a function call
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      const makeTopic = (): Topic => new Topic();
+      makeTopic().grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    // WHEN: the receiver indexes a Construct whose index signature yields a Construct
+    // NOTE: the Oxlint plugin skips this receiver, because it cannot resolve a computed member
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Registry extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      interface Registry {
+        [index: number]: Registry;
+      }
+      declare const registry: Registry;
+      registry[0].grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    // WHEN: an overloaded callee resolves to a return type with a grants property
+    // NOTE: the Oxlint plugin skips this receiver, because it cannot resolve an overload set
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      class Plain {
+        grantPublish() {}
+      }
+      function ov(value: "a"): Topic;
+      function ov(value: "b"): Plain;
+      function ov(value: unknown): Topic | Plain {
+        return value === "a" ? new Topic() : new Plain();
+      }
+      ov("a").grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    // WHEN: the receiver is an optional call returning a nullable Construct
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      const maybe = (): Topic | undefined => new Topic();
+      maybe()?.grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    // WHEN: the receiver is an array element
+    // NOTE: the Oxlint plugin skips this receiver on corsa-oxlint 1.13.1, which resolves an array
+    // element to the array type
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      declare const topics: Topic[];
+      topics[0].grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    // WHEN: the receiver is an awaited Construct
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      declare const p: Promise<Topic>;
+      async function run() {
+        (await p).grantPublish();
+      }
       `,
       errors: [{ messageId: "useGrantsProperty" }],
     },

--- a/packages/eslint/src/rules/prefer-grants-property.ts
+++ b/packages/eslint/src/rules/prefer-grants-property.ts
@@ -1,4 +1,5 @@
 import { AST_NODE_TYPES, ESLintUtils, TSESTree } from "@typescript-eslint/utils";
+import { Node, Type, TypeChecker } from "typescript";
 
 import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { findNonNullableType } from "../core/ts-type/finder/non-nullable-type";
@@ -34,26 +35,14 @@ export const preferGrantsProperty = createRule({
         const methodName = node.callee.property.name;
         if (!methodName.startsWith("grant")) return;
 
-        const objectNode = node.callee.object;
-        const tsNode = parserServices.esTreeNodeToTSNodeMap.get(objectNode);
-        // NOTE: An optional receiver such as `props.topic?.grantPublish()` is typed
-        // `Topic | undefined`, so strip the nullish members before inspecting the Construct.
-        const type = findNonNullableType(checker.getTypeAtLocation(tsNode), checker);
-        if (!isConstructTypeIgnoringSubclasses(type)) return;
-
-        const grantsProperty = type.getProperty("grants");
-        if (!grantsProperty) return;
-
-        const grantsType = checker.getTypeOfSymbolAtLocation(grantsProperty, tsNode);
-        const grantsTypeName = grantsType.symbol?.name;
-        if (!grantsTypeName?.endsWith("Grants")) return;
-
         const convertedMethodName = methodName
           .replace(/^grant/, "")
           .replace(/^./, (c) => c.toLowerCase());
 
-        const suggestedMethod = grantsType.getProperty(convertedMethodName);
-        if (!suggestedMethod) return;
+        const objectNode = node.callee.object;
+        const tsNode = parserServices.esTreeNodeToTSNodeMap.get(objectNode);
+        const type = checker.getTypeAtLocation(tsNode);
+        if (!hasGrantsMethod(type, tsNode, convertedMethodName, checker)) return;
 
         const objectName =
           objectNode.type === AST_NODE_TYPES.Identifier ? objectNode.name : "object";
@@ -71,3 +60,32 @@ export const preferGrantsProperty = createRule({
     };
   },
 });
+
+/**
+ * Check whether a Construct type exposes the given method on its grants property
+ * @param type - The type of the call receiver
+ * @param location - The node the receiver type was resolved from
+ * @param methodName - The grants method name the grant* call maps to
+ * @param checker - The TypeScript type checker
+ * @returns True if `type.grants.<methodName>()` is available, otherwise false
+ */
+const hasGrantsMethod = (
+  type: Type,
+  location: Node,
+  methodName: string,
+  checker: TypeChecker,
+): boolean => {
+  // NOTE: An optional receiver such as `props.topic?.grantPublish()` is typed
+  // `Topic | undefined`, so strip the nullish members before inspecting the Construct.
+  const receiverType = findNonNullableType(type, checker);
+  if (!isConstructTypeIgnoringSubclasses(receiverType)) return false;
+
+  const grantsProperty = receiverType.getProperty("grants");
+  if (!grantsProperty) return false;
+
+  const grantsType = checker.getTypeOfSymbolAtLocation(grantsProperty, location);
+  const grantsTypeName = grantsType.symbol?.name;
+  if (!grantsTypeName?.endsWith("Grants")) return false;
+
+  return !!grantsType.getProperty(methodName);
+};

--- a/packages/oxlint/src/__tests__/prefer-grants-property.test.ts
+++ b/packages/oxlint/src/__tests__/prefer-grants-property.test.ts
@@ -108,6 +108,137 @@ ruleTester.run("prefer-grants-property", preferGrantsProperty, {
       topic.grantPublish();
       `,
     },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Plain {
+        grantPublish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+        plain(): Plain {
+          return new Plain();
+        }
+      }
+      const topic = new Topic();
+      topic.plain().grantPublish();
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Plain {
+        grantPublish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      const fn = Object.assign((): Topic => new Topic(), { k: (): Plain => new Plain() });
+      fn["k"]().grantPublish();
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Registry extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      interface Registry {
+        [key: string]: any;
+      }
+      declare const registry: Registry;
+      registry["x"].grantPublish();
+      `,
+    },
+    // NOTE: corsa-oxlint 1.13.1 resolves an array element to the array type, so this receiver is
+    // skipped. A runtime that resolves it correctly reports it, as the ESLint plugin already does.
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      declare const topics: Topic[];
+      topics[0].grantPublish();
+      `,
+    },
+    // NOTE: the member and the object resolve to the same type here, so the receiver is skipped.
+    // The ESLint plugin reports this case.
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Registry extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      interface Registry {
+        [index: number]: Registry;
+      }
+      declare const registry: Registry;
+      registry[0].grantPublish();
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      class Plain {
+        grantPublish() {}
+      }
+      function ov(value: "a"): Topic;
+      function ov(value: "b"): Plain;
+      function ov(value: unknown): Topic | Plain {
+        return value === "a" ? new Topic() : new Plain();
+      }
+      ov("a").grantPublish();
+      `,
+    },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      class Plain {
+        grantPublish() {}
+      }
+      function ov(value: "b"): Plain;
+      function ov(value: "a"): Topic;
+      function ov(value: unknown): Topic | Plain {
+        return value === "a" ? new Topic() : new Plain();
+      }
+      ov("b").grantPublish();
+      `,
+    },
   ],
   invalid: [
     {
@@ -211,6 +342,74 @@ ruleTester.run("prefer-grants-property", preferGrantsProperty, {
       }
       declare const topic: Topic | null;
       topic.grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      class MyConstruct extends Construct {
+        run() {
+          this.helper().grantPublish();
+        }
+        helper(): Topic {
+          return new Topic();
+        }
+      }
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      const makeTopic = (): Topic => new Topic();
+      makeTopic().grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      const maybe = (): Topic | undefined => new Topic();
+      maybe()?.grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      declare const p: Promise<Topic>;
+      async function run() {
+        (await p).grantPublish();
+      }
       `,
       errors: [{ messageId: "useGrantsProperty" }],
     },

--- a/packages/oxlint/src/core/ts-type/finder/receiver-type.ts
+++ b/packages/oxlint/src/core/ts-type/finder/receiver-type.ts
@@ -1,0 +1,81 @@
+import type { CorsaTypeCheckerShape, ESTree, ParserServices } from "corsa-oxlint";
+
+import { AST_NODE_TYPES, SignatureKind } from "corsa-oxlint";
+
+/**
+ * Find the type of a member access receiver.
+ *
+ * NOTE: both checks below are mitigations for receiver shapes the pinned corsa-oxlint
+ * mis-resolves, not permanent behaviour. They are meant to be removed once the pinned version
+ * resolves those receivers, at which point the rule can resolve every receiver directly.
+ *
+ * `parserServices.getTypeAtLocation()` can resolve a computed member expression to the type of the
+ * object it indexes rather than to the indexed member, and it resolves a call to an overloaded
+ * callee to the return type of the *last* declared overload whatever the arguments are. Such
+ * receivers are reported as unresolvable instead of resolved to the wrong type; every other
+ * expression is resolved directly.
+ * @param node - The receiver expression to resolve
+ * @param parserServices - The corsa-oxlint parser services
+ * @param checker - The corsa-oxlint type checker
+ * @returns The receiver type, or undefined when it cannot be resolved
+ */
+export const findReceiverType = (
+  node: ESTree.Node,
+  parserServices: ParserServices,
+  checker: CorsaTypeCheckerShape,
+) => {
+  if (isMisresolvedComputedMember(node, parserServices)) return undefined;
+  if (node.type !== AST_NODE_TYPES.CallExpression) return parserServices.getTypeAtLocation(node);
+
+  // NOTE: a call through a mis-resolved computed member inherits the same wrong type.
+  if (isMisresolvedComputedMember(node.callee, parserServices)) return undefined;
+  if (!hasUnambiguousReturnType(node.callee, parserServices, checker)) return undefined;
+
+  return parserServices.getTypeAtLocation(node);
+};
+
+/**
+ * Check whether a computed member expression resolves to the type of the object it indexes, which
+ * is the symptom of the mis-resolution rather than the shape of the syntax. Testing the symptom
+ * keeps the receivers the runtime resolves correctly (an array or tuple element under a literal
+ * index, a `Record` value) usable as the runtime improves, and skips only the ones it still gets
+ * wrong.
+ *
+ * NOTE: the two types are compared by their `id`, which is type identity. Repeated
+ * `getTypeAtLocation()` calls hand back distinct objects, so reference equality never holds, and
+ * `typeToString` would collide for distinct types that print the same name.
+ */
+const isMisresolvedComputedMember = (
+  node: ESTree.Node,
+  parserServices: ParserServices,
+): boolean => {
+  if (node.type !== AST_NODE_TYPES.MemberExpression || !node.computed) return false;
+
+  const memberType = parserServices.getTypeAtLocation(node);
+  const objectType = parserServices.getTypeAtLocation(node.object);
+  if (!memberType || !objectType) return true;
+
+  return memberType.id === objectType.id;
+};
+
+/**
+ * Check whether every call signature of a callee returns the same type.
+ * This rule does not resolve which overload a call selects, so an overload set whose signatures
+ * disagree on the return type is treated as unresolvable rather than guessed at.
+ */
+const hasUnambiguousReturnType = (
+  calleeNode: ESTree.Node,
+  parserServices: ParserServices,
+  checker: CorsaTypeCheckerShape,
+): boolean => {
+  const calleeType = parserServices.getTypeAtLocation(calleeNode);
+  if (!calleeType) return true;
+
+  const signatures = checker.getSignaturesOfType(calleeType, SignatureKind.Call);
+  if (signatures.length < 2) return true;
+
+  const returnTypeIds = signatures.map((signature) => {
+    return checker.getReturnTypeOfSignature(signature)?.id;
+  });
+  return returnTypeIds.every((id) => id !== undefined && id === returnTypeIds[0]);
+};

--- a/packages/oxlint/src/rules/prefer-grants-property.ts
+++ b/packages/oxlint/src/rules/prefer-grants-property.ts
@@ -1,7 +1,10 @@
+import type { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
+
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { findNonNullableType } from "../core/ts-type/finder/non-nullable-type";
+import { findReceiverType } from "../core/ts-type/finder/receiver-type";
 import { createRule } from "../shared/create-rule";
 
 export const preferGrantsProperty = createRule({
@@ -35,32 +38,13 @@ export const preferGrantsProperty = createRule({
         const methodName = node.callee.property.name;
         if (!methodName.startsWith("grant")) return;
 
-        const objectNode = node.callee.object;
-        const receiverType = parserServices.getTypeAtLocation(objectNode);
-        if (!receiverType) return;
-
-        // NOTE: An optional receiver such as `props.topic?.grantPublish()` is typed
-        // `Topic | undefined`, so strip the nullish members before inspecting the Construct.
-        const type = findNonNullableType(receiverType, checker);
-        if (!isConstructTypeIgnoringSubclasses(type, checker)) return;
-
-        const grantsProperty = checker.getPropertiesOfType(type).find((s) => s.name === "grants");
-        if (!grantsProperty) return;
-
-        const grantsType = checker.getTypeOfSymbol(grantsProperty);
-        if (!grantsType) return;
-
-        const grantsTypeName = checker.getSymbolOfType(grantsType)?.name;
-        if (!grantsTypeName?.endsWith("Grants")) return;
-
         const convertedMethodName = methodName
           .replace(/^grant/, "")
           .replace(/^./, (c) => c.toLowerCase());
 
-        const suggestedMethod = checker
-          .getPropertiesOfType(grantsType)
-          .find((s) => s.name === convertedMethodName);
-        if (!suggestedMethod) return;
+        const objectNode = node.callee.object;
+        const type = findReceiverType(objectNode, parserServices, checker);
+        if (!type || !hasGrantsMethod(type, convertedMethodName, checker)) return;
 
         const objectName =
           objectNode.type === AST_NODE_TYPES.Identifier ? objectNode.name : "object";
@@ -78,3 +62,32 @@ export const preferGrantsProperty = createRule({
     };
   },
 });
+
+/**
+ * Check whether a Construct type exposes the given method on its grants property
+ * @param type - The type of the call receiver
+ * @param methodName - The grants method name the grant* call maps to
+ * @param checker - The corsa-oxlint type checker
+ * @returns True if `type.grants.<methodName>()` is available, otherwise false
+ */
+const hasGrantsMethod = (
+  type: CorsaType,
+  methodName: string,
+  checker: CorsaTypeCheckerShape,
+): boolean => {
+  // NOTE: An optional receiver such as `props.topic?.grantPublish()` is typed
+  // `Topic | undefined`, so strip the nullish members before inspecting the Construct.
+  const receiverType = findNonNullableType(type, checker);
+  if (!isConstructTypeIgnoringSubclasses(receiverType, checker)) return false;
+
+  const grantsProperty = checker.getPropertiesOfType(receiverType).find((s) => s.name === "grants");
+  if (!grantsProperty) return false;
+
+  const grantsType = checker.getTypeOfSymbol(grantsProperty);
+  if (!grantsType) return false;
+
+  const grantsTypeName = checker.getSymbolOfType(grantsType)?.name;
+  if (!grantsTypeName?.endsWith("Grants")) return false;
+
+  return checker.getPropertiesOfType(grantsType).some((s) => s.name === methodName);
+};


### PR DESCRIPTION
### Issue # (if applicable)

Refs #568.

### Reason for this change

Rebased on top of #585 / #586, with the nullish stripping applied inside `hasGrantsMethod`. The scope narrowed since the first push: `corsa-oxlint` 1.13.1 (now on `main`) fixed the plain call-expression half of #568 upstream, so what remains here are the receiver shapes 1.13.1 still gets wrong.

`prefer-grants-property` resolves the receiver of a `grant*` call with `parserServices.getTypeAtLocation()`. Measured on the pinned `corsa-oxlint` 1.13.1:

| receiver | resolves to | actual type |
| --- | --- | --- |
| `registry["x"]` (`[key: string]: any`) | `Registry` | `any` |
| `fn["k"]()` | `Topic` | `Plain` |
| `topics[0]` | `Topic[]` | `Topic` |
| `ov("b")` with `ov(v:"b"): Plain; ov(v:"a"): Topic;` | `Topic` | `Plain` |
| `ov("a")` with `ov(v:"a"): Topic; ov(v:"b"): Plain;` | `Plain` | `Topic` |

Two distinct defects. A computed member expression resolves to the type of the object it indexes rather than to the indexed member, and a call through such a member inherits that. Separately, a call to an **overloaded** callee resolves to the return type of the *last declared* overload whatever the arguments are — swapping the declaration order swaps the answer for both call sites.

Where the mis-resolved type happens to carry a matching `grants` member, the rule reports against a value that does not have it: `registry["x"].grantPublish()` is checked against `registry` itself, and `ov("b").grantPublish()` against `Topic` when the value is a `Plain`. The ESLint plugin resolves all of these correctly.

### Description of changes

Add `findReceiverType`, which returns `undefined` when a receiver cannot be trusted and otherwise resolves directly through `getTypeAtLocation`. An unresolvable receiver is skipped rather than checked against the wrong type — the same "unresolvable → skip" policy the rule already applies elsewhere. Both checks are temporary mitigations for what the pinned runtime mis-resolves, and the doc comment says so; they are meant to be removed once the pinned version resolves these receivers.

The computed-member check tests the **symptom, not the syntax**: a computed member is unresolvable only when the member expression and its object resolve to the same type, which is exactly the mis-resolution. That keeps receivers the runtime already resolves correctly usable, and means the guard narrows on its own as the runtime improves instead of over-skipping every `[]` access. The same check runs on a computed-member callee before its call is used. Types are compared by their public `id` — type identity — rather than by `typeToString`, which can collide for distinct types that print the same name.

The overload check treats a callee with two or more call signatures as unresolvable unless every signature returns the same type. **This PR does not resolve which overload a call selects**; it skips overloaded callees whose signatures disagree on the return type. (`getCallSignatureFacts(...).signature` in the public checker surface does expose the selected signature, but its `argumentTypeTexts` contract is loosely specified and this guard is temporary, so adopting it is deliberately left out of scope.) Single-signature calls keep direct resolution, so ordinary method and function receivers are unaffected.

Both plugins also get the grants lookup extracted into `hasGrantsMethod` so the two rule files keep the same structure. In each, the nullish stripping added by #586 now lives inside that helper (`findNonNullableType` → `isConstructTypeIgnoringSubclasses` → `grants` lookup on the stripped type), leaving #586's optional-receiver behaviour unchanged. **The ESLint change is structural only** — no behaviour change; its receiver resolution still goes through the TypeScript checker.

A consequence worth naming: receivers whose mis-resolved type happened to match by coincidence are now skipped too. The ESLint suite pins those (`registry[0]`, `ov("a")`, `topics[0]`) as `invalid` so the divergence stays visible rather than disappearing.

**Remaining gaps.** Verified on 1.14.0 by temporarily installing it and re-running the probe and the rule suite:

*Fixed in 1.14.0 — resolves itself on the version bump, no plugin change needed:*

- computed member with a **literal** index on an array or tuple — `topics[0]` resolves to `Topic`, `tup[1]` to `Topic`

Because the guard is a symptom check rather than a syntax check, these stop being skipped automatically. Running the Oxlint suite against 1.14.0 flips **exactly one** case — the `topics[0]` `valid` case becomes `invalid`, matching what the ESLint plugin already reports — and leaves the other 24 unchanged. That flip is expected on the bump PR and is the intended signal that the guard narrowed correctly.

*Still wrong in 1.14.0:*

- computed member with a **non-literal** index — `topics[i]`, `targets[i + 1]` and `record[key]` all resolve to the object type; `grid[i][0]` resolves to `Topic[]` instead of `Topic` (its object differs, so the guard does not skip it, but the wrong type is not a Construct so nothing is reported)
- index-signature access on a class or interface, even with a literal index — `registry["x"]` (`[key: string]: any`) and `registry[0]` (`[index: number]: Registry`) both resolve to the object
- `!` applied to a call or member — `make()!` resolves to the function type, `topics[0]!` to `Topic[]`
- generic returns — `id<T>(x: T): T` resolves to the uninstantiated `T`
- overload sets — the last-declared-overload behaviour above

These are unresolvable with the checker surface of the pinned `corsa-oxlint` 1.13.1, so #568 stays open; they are reported upstream in [corsa-bind#490](https://github.com/ubugeeei-prod/corsa-bind/issues/490).

### Description of how you validated changes

- Re-measured every receiver kind on the pinned 1.13.1 rather than carrying earlier findings forward, including the overload behaviour in both declaration orders and a single-signature control.
- Verified the 1.14.0 behaviour first-hand by temporarily installing 1.14.0, probing all eight computed-member shapes and running the Oxlint rule suite, then reverting the pin and lockfile.
- Overload guard negative control: `ov("b").grantPublish()` where the value is a `Plain` is reported by the pre-guard head (`9d2ceb6`) and skipped after this change; the other three overload permutations are unaffected.
- Both plugins gain matching cases: method-call and function-call receivers, an optional call receiver (`maybe()?.grantPublish()` with `maybe(): Topic | undefined`) and an awaited receiver (`(await p).grantPublish()`) as `invalid` — the last two pass before and after, pinning behaviour that was previously unguarded. Valid cases cover a call receiver returning a type without `grants`, a callee indexed out of a callable object, both index-signature receivers, an array element, and the overload permutation the Oxlint plugin must skip.
- The ESLint suite pins its own outcomes, which differ where the plugins diverge: it reports `ov("a")`, `registry[0]` and `topics[0]`, and stays silent on `ov("b")`.
- Every case set from `main` (`Topic | Queue`, optional / required / `void` / `null` / `Topic | string`) is kept unchanged.
- Verified on `corsa-oxlint` 1.13.1 / `oxlint` 1.81.0 / `oxlint-tsgolint` 7.0.2001 / `typescript` 7.0.2: `vp check` and `vp test --run` (834/834) pass, and `scripts/integration-test.sh` reports 43/43 for eslint:esm, eslint:cjs and oxlint.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_
