### PR TITLE
fix: exempt constructor parameter properties from public-property rules

### DIFF
--- a/packages/eslint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -210,6 +210,147 @@ ruleTester.run(
           }
         `,
       },
+      // NOTE: constructor parameter properties are intentionally out of scope for this rule
+      {
+        name: "constructor parameter property type is class that extends Resource (Bucket)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            constructor(public test: Bucket) {
+              super();
+            }
+          }
+        `,
+      },
+      {
+        name: "constructor parameter property with a default value type is class that extends Resource (Bucket)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            constructor(public test: Bucket = undefined!) {
+              super();
+            }
+          }
+        `,
+      },
+      {
+        name: "constructor parameter property type is array of class that extends Resource (Bucket[])",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            constructor(public buckets: Bucket[]) {
+              super();
+            }
+          }
+        `,
+      },
+      {
+        name: "constructor parameter property type is Array generic type wrapping class that extends Resource (Array<Bucket>)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            constructor(public buckets: Array<Bucket>) {
+              super();
+            }
+          }
+        `,
+      },
+      {
+        name: "constructor parameter property type is Readonly utility type wrapping class that extends Resource",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            constructor(public readonly bucket: Readonly<Bucket>) {
+              super();
+            }
+          }
+        `,
+      },
     ],
     invalid: [
       {
@@ -503,64 +644,6 @@ ruleTester.run(
         errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
       },
       {
-        name: "constructor public property type is class that extends Resource (Bucket)",
-        code: `
-          class Construct {}
-          class Resource {}
-          interface IBucket {
-            bucketName: string;
-          }
-          export abstract class BucketBase extends Resource implements IBucket {
-            abstract readonly bucketName: string;
-            constructor() {
-              super();
-            }
-          }
-          export class Bucket extends BucketBase {
-            readonly bucketName: string;
-            constructor() {
-              super();
-              this.bucketName = "test-bucket";
-            }
-          }
-          class TestClass extends Construct {
-            constructor(public test: Bucket) {
-              super();
-            }
-          }
-        `,
-        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      },
-      {
-        name: "constructor public property with a default value type is class that extends Resource (Bucket)",
-        code: `
-          class Construct {}
-          class Resource {}
-          interface IBucket {
-            bucketName: string;
-          }
-          export abstract class BucketBase extends Resource implements IBucket {
-            abstract readonly bucketName: string;
-            constructor() {
-              super();
-            }
-          }
-          export class Bucket extends BucketBase {
-            readonly bucketName: string;
-            constructor() {
-              super();
-              this.bucketName = "test-bucket";
-            }
-          }
-          class TestClass extends Construct {
-            constructor(public test: Bucket = undefined!) {
-              super();
-            }
-          }
-        `,
-        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      },
-      {
         name: "public field type is array of class that extends Resource (Bucket[])",
         code: `
           class Construct {}
@@ -583,35 +666,6 @@ ruleTester.run(
           }
           class TestClass extends Construct {
             public buckets: Bucket[];
-          }
-        `,
-        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      },
-      {
-        name: "constructor public property type is array of class that extends Resource (Bucket[])",
-        code: `
-          class Construct {}
-          class Resource {}
-          interface IBucket {
-            bucketName: string;
-          }
-          export abstract class BucketBase extends Resource implements IBucket {
-            abstract readonly bucketName: string;
-            constructor() {
-              super();
-            }
-          }
-          export class Bucket extends BucketBase {
-            readonly bucketName: string;
-            constructor() {
-              super();
-              this.bucketName = "test-bucket";
-            }
-          }
-          class TestClass extends Construct {
-            constructor(public buckets: Bucket[]) {
-              super();
-            }
           }
         `,
         errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
@@ -721,64 +775,6 @@ ruleTester.run(
           type MyWrapper<T> = T;
           class TestClass extends Construct {
             public bucket: MyWrapper<Bucket>;
-          }
-        `,
-        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      },
-      {
-        name: "constructor public property type is Array generic type wrapping class that extends Resource (Array<Bucket>)",
-        code: `
-          class Construct {}
-          class Resource {}
-          interface IBucket {
-            bucketName: string;
-          }
-          export abstract class BucketBase extends Resource implements IBucket {
-            abstract readonly bucketName: string;
-            constructor() {
-              super();
-            }
-          }
-          export class Bucket extends BucketBase {
-            readonly bucketName: string;
-            constructor() {
-              super();
-              this.bucketName = "test-bucket";
-            }
-          }
-          class TestClass extends Construct {
-            constructor(public buckets: Array<Bucket>) {
-              super();
-            }
-          }
-        `,
-        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      },
-      {
-        name: "constructor public property type is Readonly utility type wrapping class that extends Resource",
-        code: `
-          class Construct {}
-          class Resource {}
-          interface IBucket {
-            bucketName: string;
-          }
-          export abstract class BucketBase extends Resource implements IBucket {
-            abstract readonly bucketName: string;
-            constructor() {
-              super();
-            }
-          }
-          export class Bucket extends BucketBase {
-            readonly bucketName: string;
-            constructor() {
-              super();
-              this.bucketName = "test-bucket";
-            }
-          }
-          class TestClass extends Construct {
-            constructor(public readonly bucket: Readonly<Bucket>) {
-              super();
-            }
           }
         `,
         errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],

--- a/packages/eslint/src/__tests__/no-mutable-public-property-of-construct.test.ts
+++ b/packages/eslint/src/__tests__/no-mutable-public-property-of-construct.test.ts
@@ -92,6 +92,41 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           }
         `,
     },
+    // WHEN: constructor parameter property is mutable (parameter properties are out of scope)
+    {
+      code: `
+          class Construct {}
+          class DependencyClass extends Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public test: DependencyClass) {
+              super(scope, id);
+            }
+          }
+        `,
+    },
+    // WHEN: constructor parameter property is mutable and has a default value
+    {
+      code: `
+          class Construct {}
+          class DependencyClass extends Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public test: DependencyClass = undefined!) {
+              super(scope, id);
+            }
+          }
+        `,
+    },
+    // WHEN: constructor parameter property is mutable and has no type annotation
+    {
+      code: `
+          class Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public count) {
+              super(scope, id);
+            }
+          }
+        `,
+    },
   ],
   invalid: [
     // WHEN: public field is mutable, nested superClass is Construct
@@ -213,48 +248,6 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           class Construct {}
           class TestClass extends Construct {
             public readonly inferred = 0;
-          }
-        `,
-    },
-    // WHEN: constructor parameter property is mutable and has no type annotation
-    {
-      code: `
-          class Construct {}
-          class TestClass extends Construct {
-            constructor(scope: Construct, id: string, public count) {
-              super(scope, id);
-            }
-          }
-        `,
-      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      output: `
-          class Construct {}
-          class TestClass extends Construct {
-            constructor(scope: Construct, id: string, public readonly count) {
-              super(scope, id);
-            }
-          }
-        `,
-    },
-    // WHEN: constructor parameter property is mutable and has a default value
-    {
-      code: `
-          class Construct {}
-          class DependencyClass extends Construct {}
-          class TestClass extends Construct {
-            constructor(scope: Construct, id: string, public test: DependencyClass = undefined!) {
-              super(scope, id);
-            }
-          }
-        `,
-      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      output: `
-          class Construct {}
-          class DependencyClass extends Construct {}
-          class TestClass extends Construct {
-            constructor(scope: Construct, id: string, public readonly test: DependencyClass = undefined!) {
-              super(scope, id);
-            }
           }
         `,
     },

--- a/packages/eslint/src/core/ast-node/finder/public-property.ts
+++ b/packages/eslint/src/core/ast-node/finder/public-property.ts
@@ -1,8 +1,5 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 
-import { findConstructor } from "./constructor";
-import { findConstructorParamIdentifier } from "./constructor-param-identifier";
-
 export type PublicProperty = {
   /**
    * Name of the public property
@@ -11,10 +8,7 @@ export type PublicProperty = {
   /**
    * AST node representing the public property
    */
-  node:
-    | TSESTree.PropertyDefinitionComputedName
-    | TSESTree.PropertyDefinitionNonComputedName
-    | TSESTree.TSParameterProperty;
+  node: TSESTree.PropertyDefinitionComputedName | TSESTree.PropertyDefinitionNonComputedName;
   /**
    * Type annotation attached to the property, if any.
    * Absent when the property has no explicit annotation (e.g. `public foo = 0;`).
@@ -22,55 +16,29 @@ export type PublicProperty = {
   typeAnnotation?: TSESTree.TSTypeAnnotation;
 };
 
+/**
+ * Collects the public properties declared as class elements.
+ *
+ * NOTE: constructor parameter properties are intentionally out of scope for the public-property
+ * rules, so they are not collected here.
+ */
 export const findPublicPropertiesInClass = (node: TSESTree.ClassDeclaration): PublicProperty[] => {
-  const constructorProperties = findPropertiesInConstructor(node);
-  const classElementProperties = findPropertiesInClassElement(node);
-  return [...constructorProperties, ...classElementProperties];
-};
-
-const findPropertiesInConstructor = (node: TSESTree.ClassDeclaration) => {
-  const constructor = findConstructor(node);
-  if (!constructor) return [];
-  return constructor.value.params.flatMap((property) => findPublicProperty(property) ?? []);
-};
-
-const findPropertiesInClassElement = (node: TSESTree.ClassDeclaration): PublicProperty[] => {
   return node.body.body.flatMap((property) => findPublicProperty(property) ?? []);
 };
 
-const findPublicProperty = (
-  property: TSESTree.Parameter | TSESTree.ClassElement,
-): PublicProperty | undefined => {
-  switch (property.type) {
-    // NOTE: get from constructor
-    case AST_NODE_TYPES.TSParameterProperty: {
-      // NOTE: a default value wraps the binding in an AssignmentPattern, so unwrap it first
-      const identifier = findConstructorParamIdentifier(property);
-      if (!identifier) {
-        return;
-      }
-      if (["private", "protected"].includes(property.accessibility ?? "")) {
-        return;
-      }
-      return {
-        name: identifier.name,
-        node: property,
-        typeAnnotation: identifier.typeAnnotation,
-      };
-    }
-    // NOTE: get from class element
-    case AST_NODE_TYPES.PropertyDefinition: {
-      if (property.key.type !== AST_NODE_TYPES.Identifier) {
-        return;
-      }
-      if (["private", "protected"].includes(property.accessibility ?? "")) {
-        return;
-      }
-      return {
-        name: property.key.name,
-        node: property,
-        typeAnnotation: property.typeAnnotation,
-      };
-    }
+const findPublicProperty = (property: TSESTree.ClassElement): PublicProperty | undefined => {
+  if (property.type !== AST_NODE_TYPES.PropertyDefinition) {
+    return;
   }
+  if (property.key.type !== AST_NODE_TYPES.Identifier) {
+    return;
+  }
+  if (["private", "protected"].includes(property.accessibility ?? "")) {
+    return;
+  }
+  return {
+    name: property.key.name,
+    node: property,
+    typeAnnotation: property.typeAnnotation,
+  };
 };

--- a/packages/eslint/src/rules/no-construct-in-public-property-of-construct.ts
+++ b/packages/eslint/src/rules/no-construct-in-public-property-of-construct.ts
@@ -1,23 +1,14 @@
-import {
-  AST_NODE_TYPES,
-  ESLintUtils,
-  ParserServicesWithTypeInformation,
-  TSESLint,
-  TSESTree,
-} from "@typescript-eslint/utils";
+import { ESLintUtils, ParserServicesWithTypeInformation, TSESLint } from "@typescript-eslint/utils";
 
-import { findPublicPropertiesInClass } from "../core/ast-node/finder/public-property";
+import {
+  findPublicPropertiesInClass,
+  PublicProperty,
+} from "../core/ast-node/finder/public-property";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findTypeOfCdkConstruct } from "../core/cdk-construct/type-finder";
 import { createRule } from "../shared/create-rule";
 
 type Context = TSESLint.RuleContext<"invalidPublicPropertyOfConstruct", []>;
-
-type PublicProperty = {
-  name: string;
-  node: TSESTree.Parameter | TSESTree.ClassElement;
-  typeAnnotation?: TSESTree.TSTypeAnnotation;
-};
 
 /**
  * Disallow Construct types in public property of Construct
@@ -65,11 +56,7 @@ const validatePublicProperty = (
   // NOTE: The declared type is read from the declaration's identifier rather than from the
   // property node, because the identifier resolves consistently for every declaration form
   // (`!`, `?`, initializer) in both type checkers.
-  const typeNode =
-    publicProperty.node.type === AST_NODE_TYPES.PropertyDefinition
-      ? publicProperty.node.key
-      : publicProperty.node;
-  const type = parserServices.getTypeAtLocation(typeNode);
+  const type = parserServices.getTypeAtLocation(publicProperty.node.key);
   const constructType = findTypeOfCdkConstruct(type);
   if (constructType) {
     context.report({

--- a/packages/eslint/src/rules/no-mutable-public-property-of-construct.ts
+++ b/packages/eslint/src/rules/no-mutable-public-property-of-construct.ts
@@ -1,4 +1,4 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESLint } from "@typescript-eslint/utils";
+import { ESLintUtils, TSESLint } from "@typescript-eslint/utils";
 
 import {
   findPublicPropertiesInClass,
@@ -62,12 +62,7 @@ const validatePublicProperty = (args: { publicProperty: PublicProperty; context:
     fix: (fixer) => {
       // NOTE: TS modifier order is accessibility -> static -> override -> readonly,
       // so inserting right before the key is always a legal position
-
-      const anchor =
-        publicProperty.node.type === AST_NODE_TYPES.TSParameterProperty
-          ? publicProperty.node.parameter
-          : publicProperty.node.key;
-      return fixer.insertTextBefore(anchor, "readonly ");
+      return fixer.insertTextBefore(publicProperty.node.key, "readonly ");
     },
   });
 };

--- a/packages/oxlint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
+++ b/packages/oxlint/src/__tests__/no-construct-in-public-property-of-construct.test.ts
@@ -226,6 +226,147 @@ ruleTester.run(
           }
         `,
       },
+      // NOTE: constructor parameter properties are intentionally out of scope for this rule
+      {
+        name: "constructor parameter property type is class that extends Resource (Bucket)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            constructor(public test: Bucket) {
+              super();
+            }
+          }
+        `,
+      },
+      {
+        name: "constructor parameter property with a default value type is class that extends Resource (Bucket)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            constructor(public test: Bucket = undefined!) {
+              super();
+            }
+          }
+        `,
+      },
+      {
+        name: "constructor parameter property type is array of class that extends Resource (Bucket[])",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            constructor(public buckets: Bucket[]) {
+              super();
+            }
+          }
+        `,
+      },
+      {
+        name: "constructor parameter property type is Array generic type wrapping class that extends Resource (Array<Bucket>)",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            constructor(public buckets: Array<Bucket>) {
+              super();
+            }
+          }
+        `,
+      },
+      {
+        name: "constructor parameter property type is Readonly utility type wrapping class that extends Resource",
+        code: `
+          class Construct {}
+          class Resource {}
+          interface IBucket {
+            bucketName: string;
+          }
+          export abstract class BucketBase extends Resource implements IBucket {
+            abstract readonly bucketName: string;
+            constructor() {
+              super();
+            }
+          }
+          export class Bucket extends BucketBase {
+            readonly bucketName: string;
+            constructor() {
+              super();
+              this.bucketName = "test-bucket";
+            }
+          }
+          class TestClass extends Construct {
+            constructor(public readonly bucket: Readonly<Bucket>) {
+              super();
+            }
+          }
+        `,
+      },
     ],
     invalid: [
       {
@@ -519,64 +660,6 @@ ruleTester.run(
         errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
       },
       {
-        name: "constructor public property type is class that extends Resource (Bucket)",
-        code: `
-          class Construct {}
-          class Resource {}
-          interface IBucket {
-            bucketName: string;
-          }
-          export abstract class BucketBase extends Resource implements IBucket {
-            abstract readonly bucketName: string;
-            constructor() {
-              super();
-            }
-          }
-          export class Bucket extends BucketBase {
-            readonly bucketName: string;
-            constructor() {
-              super();
-              this.bucketName = "test-bucket";
-            }
-          }
-          class TestClass extends Construct {
-            constructor(public test: Bucket) {
-              super();
-            }
-          }
-        `,
-        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      },
-      {
-        name: "constructor public property with a default value type is class that extends Resource (Bucket)",
-        code: `
-          class Construct {}
-          class Resource {}
-          interface IBucket {
-            bucketName: string;
-          }
-          export abstract class BucketBase extends Resource implements IBucket {
-            abstract readonly bucketName: string;
-            constructor() {
-              super();
-            }
-          }
-          export class Bucket extends BucketBase {
-            readonly bucketName: string;
-            constructor() {
-              super();
-              this.bucketName = "test-bucket";
-            }
-          }
-          class TestClass extends Construct {
-            constructor(public test: Bucket = undefined!) {
-              super();
-            }
-          }
-        `,
-        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      },
-      {
         name: "public field type is array of class that extends Resource (Bucket[])",
         code: `
           class Construct {}
@@ -599,35 +682,6 @@ ruleTester.run(
           }
           class TestClass extends Construct {
             public buckets: Bucket[];
-          }
-        `,
-        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      },
-      {
-        name: "constructor public property type is array of class that extends Resource (Bucket[])",
-        code: `
-          class Construct {}
-          class Resource {}
-          interface IBucket {
-            bucketName: string;
-          }
-          export abstract class BucketBase extends Resource implements IBucket {
-            abstract readonly bucketName: string;
-            constructor() {
-              super();
-            }
-          }
-          export class Bucket extends BucketBase {
-            readonly bucketName: string;
-            constructor() {
-              super();
-              this.bucketName = "test-bucket";
-            }
-          }
-          class TestClass extends Construct {
-            constructor(public buckets: Bucket[]) {
-              super();
-            }
           }
         `,
         errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
@@ -737,64 +791,6 @@ ruleTester.run(
           type MyWrapper<T> = T;
           class TestClass extends Construct {
             public bucket: MyWrapper<Bucket>;
-          }
-        `,
-        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      },
-      {
-        name: "constructor public property type is Array generic type wrapping class that extends Resource (Array<Bucket>)",
-        code: `
-          class Construct {}
-          class Resource {}
-          interface IBucket {
-            bucketName: string;
-          }
-          export abstract class BucketBase extends Resource implements IBucket {
-            abstract readonly bucketName: string;
-            constructor() {
-              super();
-            }
-          }
-          export class Bucket extends BucketBase {
-            readonly bucketName: string;
-            constructor() {
-              super();
-              this.bucketName = "test-bucket";
-            }
-          }
-          class TestClass extends Construct {
-            constructor(public buckets: Array<Bucket>) {
-              super();
-            }
-          }
-        `,
-        errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      },
-      {
-        name: "constructor public property type is Readonly utility type wrapping class that extends Resource",
-        code: `
-          class Construct {}
-          class Resource {}
-          interface IBucket {
-            bucketName: string;
-          }
-          export abstract class BucketBase extends Resource implements IBucket {
-            abstract readonly bucketName: string;
-            constructor() {
-              super();
-            }
-          }
-          export class Bucket extends BucketBase {
-            readonly bucketName: string;
-            constructor() {
-              super();
-              this.bucketName = "test-bucket";
-            }
-          }
-          class TestClass extends Construct {
-            constructor(public readonly bucket: Readonly<Bucket>) {
-              super();
-            }
           }
         `,
         errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],

--- a/packages/oxlint/src/__tests__/no-mutable-public-property-of-construct.test.ts
+++ b/packages/oxlint/src/__tests__/no-mutable-public-property-of-construct.test.ts
@@ -79,6 +79,38 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           }
         `,
     },
+    {
+      code: `
+          class Construct {}
+          class DependencyClass extends Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public test: DependencyClass) {
+              super(scope, id);
+            }
+          }
+        `,
+    },
+    {
+      code: `
+          class Construct {}
+          class DependencyClass extends Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public test: DependencyClass = undefined!) {
+              super(scope, id);
+            }
+          }
+        `,
+    },
+    {
+      code: `
+          class Construct {}
+          class TestClass extends Construct {
+            constructor(scope: Construct, id: string, public count) {
+              super(scope, id);
+            }
+          }
+        `,
+    },
   ],
   invalid: [
     {
@@ -193,46 +225,6 @@ ruleTester.run("no-mutable-public-property-of-construct", noMutablePublicPropert
           class Construct {}
           class TestClass extends Construct {
             public readonly inferred = 0;
-          }
-        `,
-    },
-    {
-      code: `
-          class Construct {}
-          class TestClass extends Construct {
-            constructor(scope: Construct, id: string, public count) {
-              super(scope, id);
-            }
-          }
-        `,
-      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      output: `
-          class Construct {}
-          class TestClass extends Construct {
-            constructor(scope: Construct, id: string, public readonly count) {
-              super(scope, id);
-            }
-          }
-        `,
-    },
-    {
-      code: `
-          class Construct {}
-          class DependencyClass extends Construct {}
-          class TestClass extends Construct {
-            constructor(scope: Construct, id: string, public test: DependencyClass = undefined!) {
-              super(scope, id);
-            }
-          }
-        `,
-      errors: [{ messageId: "invalidPublicPropertyOfConstruct" }],
-      output: `
-          class Construct {}
-          class DependencyClass extends Construct {}
-          class TestClass extends Construct {
-            constructor(scope: Construct, id: string, public readonly test: DependencyClass = undefined!) {
-              super(scope, id);
-            }
           }
         `,
     },

--- a/packages/oxlint/src/core/ast-node/finder/public-property.ts
+++ b/packages/oxlint/src/core/ast-node/finder/public-property.ts
@@ -2,9 +2,6 @@ import type { ESTree } from "corsa-oxlint";
 
 import { AST_NODE_TYPES } from "corsa-oxlint";
 
-import { findConstructor } from "./constructor";
-import { findConstructorParamIdentifier } from "./constructor-param-identifier";
-
 type Class = ESTree.ClassDeclaration | ESTree.ClassExpression;
 
 export type PublicProperty = {
@@ -15,7 +12,7 @@ export type PublicProperty = {
   /**
    * AST node representing the public property
    */
-  node: ESTree.TSParameterProperty | ESTree.PropertyDefinition;
+  node: ESTree.PropertyDefinition;
   /**
    * Type annotation attached to the property, if any.
    * Absent when the property has no explicit annotation (e.g. `public foo = 0;`).
@@ -23,44 +20,23 @@ export type PublicProperty = {
   typeAnnotation?: ESTree.TSTypeAnnotation | null;
 };
 
+/**
+ * Collects the public properties declared as class elements.
+ *
+ * NOTE: constructor parameter properties are intentionally out of scope for the public-property
+ * rules, so they are not collected here.
+ */
 export const findPublicPropertiesInClass = (node: Class): PublicProperty[] => {
-  const constructorProperties = findPropertiesInConstructor(node);
-  const classElementProperties = findPropertiesInClassElement(node);
-  return [...constructorProperties, ...classElementProperties];
-};
-
-const findPropertiesInConstructor = (node: Class) => {
-  const constructor = findConstructor(node);
-  if (!constructor) return [];
-  return constructor.value.params.flatMap((property) => findPublicProperty(property) ?? []);
-};
-
-const findPropertiesInClassElement = (node: Class): PublicProperty[] => {
   return node.body.body.flatMap((property) => findPublicProperty(property) ?? []);
 };
 
-const findPublicProperty = (property: ESTree.Node): PublicProperty | undefined => {
-  switch (property.type) {
-    // NOTE: get from constructor
-    case AST_NODE_TYPES.TSParameterProperty: {
-      // NOTE: a default value wraps the binding in an AssignmentPattern, so unwrap it first
-      const identifier = findConstructorParamIdentifier(property);
-      if (!identifier) return;
-      if (["private", "protected"].includes(property.accessibility ?? "")) return;
-      return {
-        name: identifier.name,
-        node: property,
-        typeAnnotation: identifier.typeAnnotation,
-      };
-    }
-    case AST_NODE_TYPES.PropertyDefinition: {
-      if (property.key.type !== AST_NODE_TYPES.Identifier) return;
-      if (["private", "protected"].includes(property.accessibility ?? "")) return;
-      return {
-        name: property.key.name,
-        node: property,
-        typeAnnotation: property.typeAnnotation,
-      };
-    }
-  }
+const findPublicProperty = (property: ESTree.ClassElement): PublicProperty | undefined => {
+  if (property.type !== AST_NODE_TYPES.PropertyDefinition) return;
+  if (property.key.type !== AST_NODE_TYPES.Identifier) return;
+  if (["private", "protected"].includes(property.accessibility ?? "")) return;
+  return {
+    name: property.key.name,
+    node: property,
+    typeAnnotation: property.typeAnnotation,
+  };
 };

--- a/packages/oxlint/src/rules/no-construct-in-public-property-of-construct.ts
+++ b/packages/oxlint/src/rules/no-construct-in-public-property-of-construct.ts
@@ -1,6 +1,6 @@
 import type { ParserServices, RuleContext } from "corsa-oxlint";
 
-import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
+import { ESLintUtils } from "corsa-oxlint";
 
 import {
   findPublicPropertiesInClass,
@@ -56,11 +56,7 @@ const validatePublicProperty = (
   // NOTE: The declared type is read from the declaration's identifier rather than from the
   // property node, because the identifier resolves consistently for every declaration form
   // (`!`, `?`, initializer) in both type checkers.
-  const typeNode =
-    publicProperty.node.type === AST_NODE_TYPES.PropertyDefinition
-      ? publicProperty.node.key
-      : publicProperty.node;
-  const type = parserServices.getTypeAtLocation(typeNode);
+  const type = parserServices.getTypeAtLocation(publicProperty.node.key);
   const checker = parserServices.program.getTypeChecker();
   const constructType = findTypeOfCdkConstruct(type, checker);
   if (constructType) {

--- a/packages/oxlint/src/rules/no-mutable-public-property-of-construct.ts
+++ b/packages/oxlint/src/rules/no-mutable-public-property-of-construct.ts
@@ -1,6 +1,6 @@
 import type { RuleContext } from "corsa-oxlint";
 
-import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
+import { ESLintUtils } from "corsa-oxlint";
 
 import {
   findPublicPropertiesInClass,
@@ -62,12 +62,7 @@ const validatePublicProperty = (args: { publicProperty: PublicProperty; context:
     fix: (fixer) => {
       // NOTE: TS modifier order is accessibility -> static -> override -> readonly,
       // so inserting right before the key is always a legal position
-
-      const anchor =
-        publicProperty.node.type === AST_NODE_TYPES.TSParameterProperty
-          ? publicProperty.node.parameter
-          : publicProperty.node.key;
-      return fixer.insertTextBefore(anchor, "readonly ");
+      return fixer.insertTextBefore(publicProperty.node.key, "readonly ");
     },
   });
 };


### PR DESCRIPTION
### Issue #

Refs #564, #565.

### Reason for this change

Constructor parameter properties are intentionally out of scope for the public-property rules: they do not need to be `readonly`, do not need interface (`IXxx`) types, and do not need JSDoc.

`findPublicPropertiesInClass` nevertheless collected `TSParameterProperty` nodes, so `no-mutable-public-property-of-construct` and `no-construct-in-public-property-of-construct` reported them. This partially reverts the finder change from #576 (d5a343b), which extended that collection to the default-value form. `require-jsdoc` already ignores parameter properties (#565), and this change brings the remaining two rules in line with it.

### Description of changes

- `core/ast-node/finder/public-property.ts` (both packages): drop the constructor-derived collection and the `TSParameterProperty` member of `PublicProperty["node"]`, so the finder returns class-element properties only.
- `no-mutable-public-property-of-construct` (both packages): the fixer no longer branches on `TSParameterProperty` to pick its insertion anchor; the anchor is now always the property key.
- `no-construct-in-public-property-of-construct` (both packages): now that #581 is on main, the type resolution simplifies to `getTypeAtLocation(publicProperty.node.key)` — the parameter-property arm of its ternary is unreachable once the finder stops collecting them. The eslint rule also drops its private structural `PublicProperty` type in favour of the one exported by the finder, matching the oxlint rule.

### Description of how you validated changes

- Every parameter-property case in both rules' tests moved from `invalid` to `valid`, including the default-value cases added by #576, plus valid cases pinning the policy for the plain, default-value, and non-readonly forms. Class-field cases are unchanged.
- `vp check` clean; `vp test --run` 712 passed / 34 files (710 on main, +2 from the added valid cases).
- `vp run -r pack && bash scripts/integration-test.sh` prints SUCCESS three times; `examples/lib` has no public parameter properties, so the asserted error count stays at 43.
- Rebased onto `main` at `f98d2a4` (after #583, #585, #586 and the dependency bump in #596) and re-verified on corsa-oxlint 1.13.1 / oxlint 1.81.0: `vp check` passes and `vp test --run` passes (772 tests); CI is green on the rebased head.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_


