### PR TITLE
fix: detect pascal-case-construct-id collisions across class bodies and callbacks

### DIFF
--- a/packages/eslint/src/__tests__/pascal-case-construct-id.test.ts
+++ b/packages/eslint/src/__tests__/pascal-case-construct-id.test.ts
@@ -349,5 +349,166 @@ ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
         }
       }`,
     },
+    // WHEN: a construct created in an arrow callback converts to an id the constructor already uses
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "Logs");
+          ["a"].forEach(() => {
+            new TestClass(props, "logs");
+          });
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    // WHEN: an arrow callback holds the id the converted value would take
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "logs");
+          ["a"].forEach(() => {
+            new TestClass(props, "Logs");
+          });
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    // WHEN: a construct created in a function-expression callback converts to an id
+    //       the constructor already uses
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "Logs");
+          ["a"].forEach(function () {
+            new TestClass(props, "logs");
+          });
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    // WHEN: a function-expression callback holds the id the converted value would take
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "logs");
+          ["a"].forEach(function () {
+            new TestClass(props, "Logs");
+          });
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    // WHEN: the converted id is already used by a class property initializer
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        private readonly logs = new TestClass(undefined, "Logs");
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "logs");
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    // WHEN: an unrelated class holds the converted id — the sibling scan does not
+    //       resolve callee types, so the fix is withheld on the safe side
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class NotAConstruct {
+        constructor(name: string, label: string) {}
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new NotAConstruct("x", "Logs");
+          new TestClass(props, "logs");
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    // WHEN: a construct created in an iteration callback has no id to collide with
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          ["a"].forEach(() => {
+            new TestClass(props, "my-bucket");
+          });
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          ["a"].forEach(() => {
+            new TestClass(props, "MyBucket");
+          });
+        }
+      }`,
+    },
   ],
 });

--- a/packages/eslint/src/core/ast-node/finder/sibling-construct-id-strings.ts
+++ b/packages/eslint/src/core/ast-node/finder/sibling-construct-id-strings.ts
@@ -6,47 +6,71 @@ import { findConstructIdString } from "./construct-id-string";
 const FUNCTION_TYPES = [
   AST_NODE_TYPES.FunctionExpression,
   AST_NODE_TYPES.FunctionDeclaration,
-  AST_NODE_TYPES.ArrowFunctionExpression,
+] as const;
+
+const TRANSPARENT_PARENT_TYPES = [
+  AST_NODE_TYPES.MethodDefinition,
+  AST_NODE_TYPES.PropertyDefinition,
+  AST_NODE_TYPES.CallExpression,
 ] as const;
 
 /**
- * Collect the static construct IDs (string literals and expression-less template
- * literals) of the other constructs created in the same body as a given node.
+ * Collect the static IDs (string literals and expression-less template literals)
+ * of the other `new` expressions written in the same scope as a given node.
  *
- * NOTE: The enclosing function body approximates the construct scope. The first
- * argument, which carries the real scope, is not tracked.
+ * NOTE: The enclosing class body or function body approximates the construct
+ * scope. The first argument, which carries the real scope, is not tracked, and
+ * the callee type is not resolved either, so a `new` expression of an unrelated
+ * class also reserves an ID.
  */
 export const findSiblingConstructIdStrings = (node: TSESTree.NewExpression): string[] => {
   return collectConstructIdStrings(findScopeRoot(node), node);
 };
 
-const isFunctionNode = (node: TSESTree.Node): boolean => {
-  return FUNCTION_TYPES.some((type) => type === node.type);
+/**
+ * Check whether a node delimits the constructs created next to each other: a
+ * class body, or a function that is not transparent.
+ *
+ * NOTE: Class member bodies, arrow functions, and function expressions passed
+ * to or invoked by a call are transparent; function declarations and function
+ * expressions in any other position are scope roots. A class member body is
+ * transparent because everything a class creates hangs off the same `this`, so
+ * a property initializer and the constructor body share one scope. A callback
+ * (`items.forEach(function () { ... })`) and an IIFE are transparent because
+ * they create their constructs in the scope they are written in.
+ */
+const isScopeRoot = (node: TSESTree.Node): boolean => {
+  if (node.type === AST_NODE_TYPES.ClassBody) return true;
+  if (!FUNCTION_TYPES.some((type) => type === node.type)) return false;
+
+  const parent = node.parent;
+  if (!parent) return true;
+  return !TRANSPARENT_PARENT_TYPES.some((type) => type === parent.type);
 };
 
 /**
  * Find the node that delimits the constructs created next to a given node:
- * the nearest enclosing function body, or the whole program when the node is
+ * the nearest enclosing scope root, or the whole program when the node is
  * written at the top level of the file.
  */
 const findScopeRoot = (node: TSESTree.Node): TSESTree.Node => {
   const parent = node.parent;
   if (!parent) return node;
-  if (isFunctionNode(parent)) return parent;
+  if (isScopeRoot(parent)) return parent;
   return findScopeRoot(parent);
 };
 
 /**
  * Collect the static ID of every `NewExpression` below a node, skipping the
- * target itself and never descending into a nested function body because those
- * constructs belong to another scope root.
+ * target itself and never descending into a nested scope root because those
+ * constructs belong to another scope.
  */
 const collectConstructIdStrings = (
   node: TSESTree.Node,
   target: TSESTree.NewExpression,
 ): string[] => {
   const descendantIds = findChildNodes(node).flatMap((child) => {
-    if (isFunctionNode(child)) return [];
+    if (isScopeRoot(child)) return [];
     return collectConstructIdStrings(child, target);
   });
 

--- a/packages/eslint/src/rules/pascal-case-construct-id.ts
+++ b/packages/eslint/src/rules/pascal-case-construct-id.ts
@@ -77,14 +77,17 @@ const findQuoteType = (node: TSESTree.Node): QuoteType => {
 };
 
 /**
- * Check whether another construct created in the same body already owns the
- * converted ID. `toPascalCase` is lossy ("Logs" and "logs" both become "Logs"),
- * so fixing such an ID would create a duplicate construct ID that throws at
- * synth time.
+ * Check whether another construct created in the same class body or function
+ * body already owns the converted ID. `toPascalCase` is lossy ("Logs" and
+ * "logs" both become "Logs"), so fixing such an ID would create a duplicate
+ * construct ID that throws at synth time.
  */
 const isTakenByAnotherConstruct = (node: TSESTree.NewExpression, pascalCaseValue: string) => {
   // NOTE: Compare against the raw sibling IDs and their converted forms, so that
   // several case variants of one word are not all fixed onto the same ID either.
+  // The sibling scan only approximates the scope, so a `new` expression of an
+  // unrelated class can withhold the fix. Reporting without a fix is the safe
+  // direction, so the approximation is kept on the conservative side.
   return findSiblingConstructIdStrings(node).some(
     (siblingId) => siblingId === pascalCaseValue || toPascalCase(siblingId) === pascalCaseValue,
   );
@@ -106,7 +109,8 @@ const validateConstructId = (node: TSESTree.NewExpression, context: Context) => 
   const pascalCaseValue = toPascalCase(constructId);
   // Skip the fix when the converted value would still fail validation
   // (e.g. leading digits, symbol-only input) so the fix always converges,
-  // or when it would collide with another construct ID in the same body.
+  // or when it would collide with another construct ID in the same class body or
+  // function body.
   if (!isPascalCase(pascalCaseValue) || isTakenByAnotherConstruct(node, pascalCaseValue)) {
     context.report({ node: secondArg, messageId: "invalidConstructId" });
     return;

--- a/packages/oxlint/src/__tests__/pascal-case-construct-id.test.ts
+++ b/packages/oxlint/src/__tests__/pascal-case-construct-id.test.ts
@@ -303,5 +303,157 @@ ruleTester.run("pascal-case-construct-id", pascalCaseConstructId, {
         }
       }`,
     },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "Logs");
+          ["a"].forEach(() => {
+            new TestClass(props, "logs");
+          });
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "logs");
+          ["a"].forEach(() => {
+            new TestClass(props, "Logs");
+          });
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "Logs");
+          ["a"].forEach(function () {
+            new TestClass(props, "logs");
+          });
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "logs");
+          ["a"].forEach(function () {
+            new TestClass(props, "Logs");
+          });
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        private readonly logs = new TestClass(undefined, "Logs");
+        constructor(props: any, id: string) {
+          super(props, id);
+          new TestClass(props, "logs");
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class NotAConstruct {
+        constructor(name: string, label: string) {}
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          new NotAConstruct("x", "Logs");
+          new TestClass(props, "logs");
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: null,
+    },
+    {
+      code: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          ["a"].forEach(() => {
+            new TestClass(props, "my-bucket");
+          });
+        }
+      }`,
+      errors: [{ messageId: "invalidConstructId" }],
+      output: `
+      class Construct {}
+      class TestClass extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+        }
+      }
+      class ParentConstruct extends Construct {
+        constructor(props: any, id: string) {
+          super(props, id);
+          ["a"].forEach(() => {
+            new TestClass(props, "MyBucket");
+          });
+        }
+      }`,
+    },
   ],
 });

--- a/packages/oxlint/src/core/ast-node/finder/sibling-construct-id-strings.ts
+++ b/packages/oxlint/src/core/ast-node/finder/sibling-construct-id-strings.ts
@@ -8,46 +8,70 @@ import { findConstructIdString } from "./construct-id-string";
 const FUNCTION_TYPES = [
   AST_NODE_TYPES.FunctionExpression,
   AST_NODE_TYPES.FunctionDeclaration,
-  AST_NODE_TYPES.ArrowFunctionExpression,
+] as const;
+
+const TRANSPARENT_PARENT_TYPES = [
+  AST_NODE_TYPES.MethodDefinition,
+  AST_NODE_TYPES.PropertyDefinition,
+  AST_NODE_TYPES.CallExpression,
 ] as const;
 
 /**
- * Collect the static construct IDs (string literals and expression-less template
- * literals) of the other constructs created in the same body as a given node.
+ * Collect the static IDs (string literals and expression-less template literals)
+ * of the other `new` expressions written in the same scope as a given node.
  *
- * NOTE: The enclosing function body approximates the construct scope. The first
- * argument, which carries the real scope, is not tracked.
+ * NOTE: The enclosing class body or function body approximates the construct
+ * scope. The first argument, which carries the real scope, is not tracked, and
+ * the callee type is not resolved either, so a `new` expression of an unrelated
+ * class also reserves an ID.
  */
 export const findSiblingConstructIdStrings = (node: ESTree.NewExpression): string[] => {
   return collectConstructIdStrings(findScopeRoot(node), node);
 };
 
-const isFunctionNode = (node: ESTree.Node): boolean => {
+/**
+ * Check whether a node delimits the constructs created next to each other: a
+ * class body, or a function that is not transparent.
+ *
+ * NOTE: Class member bodies, arrow functions, and function expressions passed
+ * to or invoked by a call are transparent; function declarations and function
+ * expressions in any other position are scope roots. A class member body is
+ * transparent because everything a class creates hangs off the same `this`, so
+ * a property initializer and the constructor body share one scope. A callback
+ * (`items.forEach(function () { ... })`) and an IIFE are transparent because
+ * they create their constructs in the scope they are written in.
+ */
+const isScopeRoot = (node: ESTree.Node): boolean => {
+  if (node.type === AST_NODE_TYPES.ClassBody) return true;
   // NOTE: Corsa's wide node union does not narrow via Array.includes,
   // so use .some with equality to keep type inference happy.
-  return FUNCTION_TYPES.some((type) => type === node.type);
+  if (!FUNCTION_TYPES.some((type) => type === node.type)) return false;
+
+  const parent = node.parent;
+  if (!parent) return true;
+  return !TRANSPARENT_PARENT_TYPES.some((type) => type === parent.type);
 };
 
 /**
  * Find the node that delimits the constructs created next to a given node:
- * the nearest enclosing function body, or the whole program when the node is
+ * the nearest enclosing scope root, or the whole program when the node is
  * written at the top level of the file.
  */
 const findScopeRoot = (node: ESTree.Node): ESTree.Node => {
   const parent = node.parent;
   if (!parent) return node;
-  if (isFunctionNode(parent)) return parent;
+  if (isScopeRoot(parent)) return parent;
   return findScopeRoot(parent);
 };
 
 /**
  * Collect the static ID of every `NewExpression` below a node, skipping the
- * target itself and never descending into a nested function body because those
- * constructs belong to another scope root.
+ * target itself and never descending into a nested scope root because those
+ * constructs belong to another scope.
  */
 const collectConstructIdStrings = (node: ESTree.Node, target: ESTree.NewExpression): string[] => {
   const descendantIds = findChildNodes(node).flatMap((child) => {
-    if (isFunctionNode(child)) return [];
+    if (isScopeRoot(child)) return [];
     return collectConstructIdStrings(child, target);
   });
 

--- a/packages/oxlint/src/rules/pascal-case-construct-id.ts
+++ b/packages/oxlint/src/rules/pascal-case-construct-id.ts
@@ -73,14 +73,17 @@ const findQuoteType = (node: ESTree.Node): QuoteType => {
 };
 
 /**
- * Check whether another construct created in the same body already owns the
- * converted ID. `toPascalCase` is lossy ("Logs" and "logs" both become "Logs"),
- * so fixing such an ID would create a duplicate construct ID that throws at
- * synth time.
+ * Check whether another construct created in the same class body or function
+ * body already owns the converted ID. `toPascalCase` is lossy ("Logs" and
+ * "logs" both become "Logs"), so fixing such an ID would create a duplicate
+ * construct ID that throws at synth time.
  */
 const isTakenByAnotherConstruct = (node: ESTree.NewExpression, pascalCaseValue: string) => {
   // NOTE: Compare against the raw sibling IDs and their converted forms, so that
   // several case variants of one word are not all fixed onto the same ID either.
+  // The sibling scan only approximates the scope, so a `new` expression of an
+  // unrelated class can withhold the fix. Reporting without a fix is the safe
+  // direction, so the approximation is kept on the conservative side.
   return findSiblingConstructIdStrings(node).some(
     (siblingId) => siblingId === pascalCaseValue || toPascalCase(siblingId) === pascalCaseValue,
   );
@@ -102,7 +105,8 @@ const validateConstructId = (node: ESTree.NewExpression, context: RuleContext) =
   const pascalCaseValue = toPascalCase(constructId);
   // Skip the fix when the converted value would still fail validation
   // (e.g. leading digits, symbol-only input) so the fix always converges,
-  // or when it would collide with another construct ID in the same body.
+  // or when it would collide with another construct ID in the same class body or
+  // function body.
   if (!isPascalCase(pascalCaseValue) || isTakenByAnotherConstruct(node, pascalCaseValue)) {
     context.report({ node: secondArg, messageId: "invalidConstructId" });
     return;


### PR DESCRIPTION
### Issue # (if applicable)

N/A — follow-up to #580 (review finding).

### Reason for this change

#580 made the `pascal-case-construct-id` autofix abstain when the converted ID collides with another static construct ID, but the sibling scan bounded the scope at the nearest function body. Constructs that live in the same construct scope but in a different function body therefore stayed invisible to each other, and the fixer still produced duplicate construct IDs — a synth-time error.

Reproduced on `origin/main` with the built plugins and a rule-isolated config (`awscdk/pascal-case-construct-id` only; ESLint flat config, and `.oxlintrc.json` with `jsPlugins: ["oxlint-plugin-awscdk"]` + `options.typeAware: true`).

```ts
// (a) sibling inside an iteration callback — arrow and `function` alike
class ParentConstruct extends Construct {
  constructor(props: any, id: string) {
    super(props, id);
    new TestClass(props, "Logs");
    ["a"].forEach(() => {
      new TestClass(props, "logs");
    });
  }
}

// (b) the mirror of (a): "logs" in the constructor, "Logs" in the callback

// (c) class property initializer — the `public readonly table = new Table(this, "Table")` shape
class ParentConstruct extends Construct {
  private readonly a = new TestClass(undefined, "Logs");
  constructor(props: any, id: string) {
    super(props, id);
    new TestClass(props, "logs");
  }
}

// (d) a non-construct `new` expression holds the converted id
class ParentConstruct extends Construct {
  constructor(props: any, id: string) {
    super(props, id);
    new NotAConstruct("x", "Logs");
    new TestClass(props, "logs");
  }
}
```

`eslint --fix-dry-run --format json` on `origin/main` (`output` present = ESLint rewrote the file):

```
----- (a) ----- errorCount=1 fixableErrorCount=1
    new TestClass(props, "Logs");
    ["a"].forEach(() => { new TestClass(props, "Logs"); });   // was "logs" — duplicate
----- (b) ----- errorCount=1 fixableErrorCount=1
    new TestClass(props, "Logs");                             // was "logs" — duplicate
    ["a"].forEach(() => { new TestClass(props, "Logs"); });
----- (c) ----- errorCount=1 fixableErrorCount=1
  private readonly a = new TestClass(undefined, "Logs");
    new TestClass(props, "Logs");                             // was "logs" — duplicate
----- (d) ----- errorCount=1 fixableErrorCount=0, output absent
  new NotAConstruct("x", "Logs");
  new TestClass(props, "logs");                               // reported, fix withheld
```

`oxlint --fix` produced byte-identical rewrites for (a), (b) and (c), and left (d) alone:

```
repro/p4.ts:14:26: Construct ID must be PascalCase. [Error/awscdk(pascal-case-construct-id)]
```

The `function () { ... }` form of (a)/(b) behaves the same way and is fixed here too.

After this change both plugins abstain on (a) through (d) — ESLint reports `errorCount=1 fixableErrorCount=0` with no `output`, and `oxlint --fix` leaves every file byte-identical — while a callback construct with nothing to collide with is still fixed (`"my-bucket"` → `"MyBucket"`, in both the arrow and the `function` form).

### Description of changes

- Replaced the finder's "nearest enclosing function" scope root with a scope model in which a `ClassBody` is a scope root and a function is a scope root unless it is transparent. Class member bodies, arrow functions, and function expressions passed to or invoked by a call are transparent; function declarations and function expressions in any other position stay scope roots. A property initializer and the constructor body therefore share one scope, matching the fact that everything a class creates hangs off the same `this`, and an iteration callback or IIFE is scanned together with the body it is written in.
- The same predicate now bounds the upward walk and the downward collection, so the two directions cannot disagree.
- Kept the non-construct `new` expression of (d) counted as a sibling rather than resolving callee types. The finder is type-free, and threading the type checker through it to filter siblings is far more invasive than the defect warrants; the failure mode is a withheld fix, which is the safe direction. Documented the approximation in the finder's doc comment (which previously overstated the scan as covering "the other constructs") and in the rule's `NOTE`, and pinned it with a test.

### Description of how you validated changes

- Added seven cases to both packages' `pascal-case-construct-id` suites: four callback abstentions (arrow and `function`, in both directions), the property-initializer abstention, the pinned non-construct approximation, and a positive control that a callback construct with no collision is still fixed. Existing cases are unchanged.
- Negative controls, both run with the new tests in place and only the finder reverted:
  - against `origin/main`'s finder, the three class-body/arrow abstentions fail per package (`6 failed | 41 passed (47)`);
  - against the first revision of this branch, the two `function`-expression abstentions fail per package (`4 failed | 47 passed (51)`).
  In every failing case the fixer rewrote the id to a duplicate `"Logs"`. With the finder in place all 51 pass.
- `vp check` (249 files formatted, 0 lint/type errors), `vp test --run` (34 files, 734 tests passed), `vp run -r pack && bash scripts/integration-test.sh` (3× SUCCESS, 43 errors). Verified after rebasing on `main` and reinstalling, on corsa-oxlint 1.12.4, oxlint 1.80.0, oxlint-tsgolint 7.0.2001, ESLint 10.9.1.
- Rebased onto `main` at `28f46a8` (after #583, #585, #586, #592, #594 and the dependency bump in #596) and re-verified on corsa-oxlint 1.13.1 / oxlint 1.81.0: `vp check` passes and `vp test --run` passes (812 tests); CI is green on the rebased head.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_




