### PR TITLE
fix: skip computed property keys in property-name based rules

### DIFF
--- a/packages/eslint/src/__tests__/no-construct-in-interface.test.ts
+++ b/packages/eslint/src/__tests__/no-construct-in-interface.test.ts
@@ -171,6 +171,57 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       }
       `,
     },
+    {
+      name: "computed identifier key is skipped even when the property type is a construct class",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      const bucketKey = "bucket";
+      interface MyConstructProps {
+        readonly [bucketKey]: Bucket;
+      }
+      `,
+    },
+    {
+      name: "computed string literal key is skipped even when the property type is a construct class",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        readonly ["quotedBucket"]: Bucket;
+      }
+      `,
+    },
   ],
   invalid: [
     {
@@ -955,6 +1006,37 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       errors: [
         { messageId: "invalidInterfaceProperty" },
         { messageId: "invalidInterfaceProperty" },
+      ],
+    },
+    {
+      name: "numeric literal key is reported under its stringified value",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        readonly 1: Bucket;
+      }
+      `,
+      errors: [
+        {
+          messageId: "invalidInterfaceProperty",
+          data: { propertyName: "1", typeName: "Bucket" },
+        },
       ],
     },
   ],

--- a/packages/eslint/src/__tests__/no-mutable-property-of-props-interface.test.ts
+++ b/packages/eslint/src/__tests__/no-mutable-property-of-props-interface.test.ts
@@ -50,6 +50,23 @@ ruleTester.run("no-mutable-property-of-props-interface", noMutablePropertyOfProp
         }
       `,
     },
+    // WHEN: Computed identifier key (the property name is not the key source text)
+    {
+      code: `
+        const nameKey = "name";
+        interface ComputedKeyProps {
+          [nameKey]: string;
+        }
+      `,
+    },
+    // WHEN: Computed string literal key
+    {
+      code: `
+        interface ComputedKeyProps {
+          ["bucket-name"]: string;
+        }
+      `,
+    },
   ],
   invalid: [
     // WHEN: readonly is not set
@@ -123,6 +140,25 @@ ruleTester.run("no-mutable-property-of-props-interface", noMutablePropertyOfProp
       errors: [
         { messageId: "invalidPropertyOfPropsInterface" },
         { messageId: "invalidPropertyOfPropsInterface" },
+      ],
+    },
+    // WHEN: Numeric literal property key does not have readonly
+    {
+      code: `
+        interface NumericKeyProps {
+          1: string;
+        }
+      `,
+      output: `
+        interface NumericKeyProps {
+          readonly 1: string;
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidPropertyOfPropsInterface",
+          data: { propertyName: "1" },
+        },
       ],
     },
   ],

--- a/packages/eslint/src/__tests__/require-jsdoc.test.ts
+++ b/packages/eslint/src/__tests__/require-jsdoc.test.ts
@@ -60,6 +60,33 @@ ruleTester.run("require-jsdoc", requireJSDoc, {
         }
       `,
     },
+    {
+      // WHEN: Computed identifier key (the property name is not the key source text)
+      code: `
+        const nameKey = "name";
+        interface TestProps {
+          [nameKey]: string;
+        }
+      `,
+    },
+    {
+      // WHEN: Computed string literal key
+      code: `
+        interface TestProps {
+          ["bucket-name"]: string;
+        }
+      `,
+    },
+    {
+      // WHEN: Computed key on a public property of a Construct class
+      code: `
+        class Construct {}
+        const nameKey = "name";
+        class TestConstruct extends Construct {
+          public [nameKey]: string;
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -159,6 +186,20 @@ ruleTester.run("require-jsdoc", requireJSDoc, {
         {
           messageId: "missingJSDoc",
           data: { propertyName: "bucketName" },
+        },
+      ],
+    },
+    {
+      // WHEN: numeric literal key without documentation
+      code: `
+        interface TestProps {
+          1: string;
+        }
+      `,
+      errors: [
+        {
+          messageId: "missingJSDoc",
+          data: { propertyName: "1" },
         },
       ],
     },

--- a/packages/eslint/src/__tests__/require-props-default-doc.test.ts
+++ b/packages/eslint/src/__tests__/require-props-default-doc.test.ts
@@ -59,6 +59,23 @@ ruleTester.run("require-default-doc-optional-props", requirePropsDefaultDoc, {
         }
       `,
     },
+    {
+      // WHEN: Optional property has a computed identifier key
+      code: `
+        const nameKey = "name";
+        interface MyConstructProps {
+          [nameKey]?: string;
+        }
+      `,
+    },
+    {
+      // WHEN: Optional property has a computed string literal key
+      code: `
+        interface MyConstructProps {
+          ["bucket-name"]?: string;
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -150,6 +167,20 @@ ruleTester.run("require-default-doc-optional-props", requirePropsDefaultDoc, {
         {
           messageId: "missingDefaultDoc",
           data: { propertyName: "bucket-name" },
+        },
+      ],
+    },
+    {
+      // WHEN: Optional property has numeric literal key without documentation
+      code: `
+        interface MyConstructProps {
+          1?: string;
+        }
+      `,
+      errors: [
+        {
+          messageId: "missingDefaultDoc",
+          data: { propertyName: "1" },
         },
       ],
     },

--- a/packages/eslint/src/core/ast-node/finder/static-property-key.ts
+++ b/packages/eslint/src/core/ast-node/finder/static-property-key.ts
@@ -1,13 +1,19 @@
 import { AST_NODE_TYPES, TSESTree } from "@typescript-eslint/utils";
 
+type PropertyLike = TSESTree.PropertyDefinition | TSESTree.TSPropertySignature;
+
 /**
- * Find the statically known name of a property key
- * @param key The key node of a property signature, property definition or property
+ * Find the statically known name of a property
+ * @param property A property signature or property definition node
  * @returns The name for an Identifier key and the stringified value for a string or numeric
- * Literal key, or null for keys that cannot be resolved statically (computed keys, template
- * literals, etc.)
+ * Literal key, or null for properties whose name cannot be resolved statically (computed keys,
+ * private identifiers, template literals, etc.)
  */
-export const findStaticPropertyName = (key: TSESTree.Node): string | null => {
+export const findStaticPropertyName = (property: PropertyLike): string | null => {
+  // NOTE: a computed key is an expression, so its source text is not the property name
+  if (property.computed) return null;
+
+  const key = property.key;
   if (key.type === AST_NODE_TYPES.Identifier) return key.name;
   if (
     key.type === AST_NODE_TYPES.Literal &&

--- a/packages/eslint/src/rules/no-construct-in-interface.ts
+++ b/packages/eslint/src/rules/no-construct-in-interface.ts
@@ -30,8 +30,9 @@ export const noConstructInInterface = createRule({
         for (const property of node.body.body) {
           if (property.type !== AST_NODE_TYPES.TSPropertySignature) continue;
 
-          // NOTE: computed keys cannot be resolved statically, so they are skipped
-          const propertyName = findStaticPropertyName(property.key);
+          // NOTE: properties whose name cannot be resolved statically (computed keys, etc.)
+          // are out of scope for this rule
+          const propertyName = findStaticPropertyName(property);
           if (propertyName === null) continue;
 
           const type = parserServices.getTypeAtLocation(property);

--- a/packages/eslint/src/rules/no-mutable-property-of-props-interface.ts
+++ b/packages/eslint/src/rules/no-mutable-property-of-props-interface.ts
@@ -38,8 +38,9 @@ export const noMutablePropertyOfPropsInterface = createRule({
           // NOTE: Skip if already readonly
           if (property.readonly) continue;
 
-          // NOTE: computed keys cannot be resolved statically, so they are skipped
-          const propertyName = findStaticPropertyName(property.key);
+          // NOTE: properties whose name cannot be resolved statically (computed keys, etc.)
+          // are out of scope for this rule
+          const propertyName = findStaticPropertyName(property);
           if (propertyName === null) continue;
 
           context.report({

--- a/packages/eslint/src/rules/require-jsdoc.ts
+++ b/packages/eslint/src/rules/require-jsdoc.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from "@typescript-eslint/utils";
 
 import { findAttachedJSDocComments } from "../core/ast-node/finder/attached-jsdoc-comment";
+import { findStaticPropertyName } from "../core/ast-node/finder/static-property-key";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
@@ -27,12 +28,10 @@ export const requireJSDoc = createRule({
     const parserServices = ESLintUtils.getParserServices(context);
     return {
       TSPropertySignature(node) {
-        if (
-          node.key.type !== AST_NODE_TYPES.Identifier &&
-          node.key.type !== AST_NODE_TYPES.Literal
-        ) {
-          return;
-        }
+        // NOTE: properties whose name cannot be resolved statically (computed keys, etc.)
+        // are out of scope for this rule
+        const propertyName = findStaticPropertyName(node);
+        if (propertyName === null) return;
 
         // NOTE: Check if the parent is an interface
         const parent = node.parent.parent;
@@ -44,8 +43,6 @@ export const requireJSDoc = createRule({
         const comments = findAttachedJSDocComments(context.sourceCode, node);
         if (comments.length > 0) return;
 
-        const propertyName =
-          node.key.type === AST_NODE_TYPES.Identifier ? node.key.name : String(node.key.value);
         context.report({
           node,
           messageId: "missingJSDoc",
@@ -53,13 +50,12 @@ export const requireJSDoc = createRule({
         });
       },
       PropertyDefinition(node) {
-        if (
-          (node.key.type !== AST_NODE_TYPES.Identifier &&
-            node.key.type !== AST_NODE_TYPES.Literal) ||
-          node.parent.type !== AST_NODE_TYPES.ClassBody
-        ) {
-          return;
-        }
+        if (node.parent.type !== AST_NODE_TYPES.ClassBody) return;
+
+        // NOTE: properties whose name cannot be resolved statically (computed keys, etc.)
+        // are out of scope for this rule
+        const propertyName = findStaticPropertyName(node);
+        if (propertyName === null) return;
 
         // NOTE: Check if the class extends Construct
         const classDeclaration = node.parent.parent;
@@ -80,8 +76,6 @@ export const requireJSDoc = createRule({
         const comments = findAttachedJSDocComments(context.sourceCode, node);
         if (comments.length > 0) return;
 
-        const propertyName =
-          node.key.type === AST_NODE_TYPES.Identifier ? node.key.name : String(node.key.value);
         context.report({
           node,
           messageId: "missingJSDoc",

--- a/packages/eslint/src/rules/require-props-default-doc.ts
+++ b/packages/eslint/src/rules/require-props-default-doc.ts
@@ -4,6 +4,7 @@ import {
   findAttachedJSDocComments,
   hasDefaultTag,
 } from "../core/ast-node/finder/attached-jsdoc-comment";
+import { findStaticPropertyName } from "../core/ast-node/finder/static-property-key";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -29,14 +30,10 @@ export const requirePropsDefaultDoc = createRule({
   create(context) {
     return {
       TSPropertySignature(node) {
-        // NOTE: Only Identifier / Literal (string or numeric) keys are checked.
-        // Computed keys are out of scope for this rule.
-        if (
-          node.key.type !== AST_NODE_TYPES.Identifier &&
-          node.key.type !== AST_NODE_TYPES.Literal
-        ) {
-          return;
-        }
+        // NOTE: properties whose name cannot be resolved statically (computed keys, etc.)
+        // are out of scope for this rule
+        const propertyName = findStaticPropertyName(node);
+        if (propertyName === null) return;
 
         // NOTE: Check if the property is optional
         if (!node.optional) return;
@@ -51,8 +48,6 @@ export const requirePropsDefaultDoc = createRule({
         const comments = findAttachedJSDocComments(context.sourceCode, node);
         if (hasDefaultTag(comments)) return;
 
-        const propertyName =
-          node.key.type === AST_NODE_TYPES.Identifier ? node.key.name : String(node.key.value);
         context.report({
           node,
           messageId: "missingDefaultDoc",

--- a/packages/oxlint/src/__tests__/no-construct-in-interface.test.ts
+++ b/packages/oxlint/src/__tests__/no-construct-in-interface.test.ts
@@ -209,6 +209,57 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       }
       `,
     },
+    {
+      name: "computed identifier key is skipped even when the property type is a construct class",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      const bucketKey = "bucket";
+      interface MyConstructProps {
+        readonly [bucketKey]: Bucket;
+      }
+      `,
+    },
+    {
+      name: "computed string literal key is skipped even when the property type is a construct class",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        readonly ["quotedBucket"]: Bucket;
+      }
+      `,
+    },
   ],
   invalid: [
     {
@@ -993,6 +1044,37 @@ ruleTester.run("no-construct-in-interface", noConstructInInterface, {
       errors: [
         { messageId: "invalidInterfaceProperty" },
         { messageId: "invalidInterfaceProperty" },
+      ],
+    },
+    {
+      name: "numeric literal key is reported under its stringified value",
+      code: `
+      class Resource {}
+      interface IBucket {
+        bucketName: string;
+      }
+      export abstract class BucketBase extends Resource implements IBucket {
+        abstract readonly bucketName: string;
+        constructor() {
+          super();
+        }
+      }
+      export class Bucket extends BucketBase {
+        readonly bucketName: string;
+        constructor() {
+          super();
+          this.bucketName = "test-bucket";
+        }
+      }
+      interface MyConstructProps {
+        readonly 1: Bucket;
+      }
+      `,
+      errors: [
+        {
+          messageId: "invalidInterfaceProperty",
+          data: { propertyName: "1", typeName: "Bucket" },
+        },
       ],
     },
   ],

--- a/packages/oxlint/src/__tests__/no-mutable-property-of-props-interface.test.ts
+++ b/packages/oxlint/src/__tests__/no-mutable-property-of-props-interface.test.ts
@@ -44,6 +44,23 @@ ruleTester.run("no-mutable-property-of-props-interface", noMutablePropertyOfProp
         }
       `,
     },
+    // WHEN: Computed identifier key (the property name is not the key source text)
+    {
+      code: `
+        const nameKey = "name";
+        interface ComputedKeyProps {
+          [nameKey]: string;
+        }
+      `,
+    },
+    // WHEN: Computed string literal key
+    {
+      code: `
+        interface ComputedKeyProps {
+          ["bucket-name"]: string;
+        }
+      `,
+    },
   ],
   invalid: [
     // WHEN: readonly is not set
@@ -117,6 +134,25 @@ ruleTester.run("no-mutable-property-of-props-interface", noMutablePropertyOfProp
       errors: [
         { messageId: "invalidPropertyOfPropsInterface" },
         { messageId: "invalidPropertyOfPropsInterface" },
+      ],
+    },
+    // WHEN: Numeric literal property key does not have readonly
+    {
+      code: `
+        interface NumericKeyProps {
+          1: string;
+        }
+      `,
+      output: `
+        interface NumericKeyProps {
+          readonly 1: string;
+        }
+      `,
+      errors: [
+        {
+          messageId: "invalidPropertyOfPropsInterface",
+          data: { propertyName: "1" },
+        },
       ],
     },
   ],

--- a/packages/oxlint/src/__tests__/require-jsdoc.test.ts
+++ b/packages/oxlint/src/__tests__/require-jsdoc.test.ts
@@ -54,6 +54,33 @@ ruleTester.run("require-jsdoc", requireJSDoc, {
         }
       `,
     },
+    {
+      // WHEN: Computed identifier key (the property name is not the key source text)
+      code: `
+        const nameKey = "name";
+        interface TestProps {
+          [nameKey]: string;
+        }
+      `,
+    },
+    {
+      // WHEN: Computed string literal key
+      code: `
+        interface TestProps {
+          ["bucket-name"]: string;
+        }
+      `,
+    },
+    {
+      // WHEN: Computed key on a public property of a Construct class
+      code: `
+        class Construct {}
+        const nameKey = "name";
+        class TestConstruct extends Construct {
+          public [nameKey]: string;
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -153,6 +180,20 @@ ruleTester.run("require-jsdoc", requireJSDoc, {
         {
           messageId: "missingJSDoc",
           data: { propertyName: "bucketName" },
+        },
+      ],
+    },
+    {
+      // WHEN: numeric literal key without documentation
+      code: `
+        interface TestProps {
+          1: string;
+        }
+      `,
+      errors: [
+        {
+          messageId: "missingJSDoc",
+          data: { propertyName: "1" },
         },
       ],
     },

--- a/packages/oxlint/src/__tests__/require-props-default-doc.test.ts
+++ b/packages/oxlint/src/__tests__/require-props-default-doc.test.ts
@@ -53,6 +53,23 @@ ruleTester.run("require-props-default-doc", requirePropsDefaultDoc, {
         }
       `,
     },
+    {
+      // WHEN: Optional property has a computed identifier key
+      code: `
+        const nameKey = "name";
+        interface MyConstructProps {
+          [nameKey]?: string;
+        }
+      `,
+    },
+    {
+      // WHEN: Optional property has a computed string literal key
+      code: `
+        interface MyConstructProps {
+          ["bucket-name"]?: string;
+        }
+      `,
+    },
   ],
   invalid: [
     {
@@ -144,6 +161,20 @@ ruleTester.run("require-props-default-doc", requirePropsDefaultDoc, {
         {
           messageId: "missingDefaultDoc",
           data: { propertyName: "bucket-name" },
+        },
+      ],
+    },
+    {
+      // WHEN: Optional property has numeric literal key without documentation
+      code: `
+        interface MyConstructProps {
+          1?: string;
+        }
+      `,
+      errors: [
+        {
+          messageId: "missingDefaultDoc",
+          data: { propertyName: "1" },
         },
       ],
     },

--- a/packages/oxlint/src/core/ast-node/finder/static-property-key.ts
+++ b/packages/oxlint/src/core/ast-node/finder/static-property-key.ts
@@ -2,14 +2,20 @@ import type { ESTree } from "corsa-oxlint";
 
 import { AST_NODE_TYPES } from "corsa-oxlint";
 
+type PropertyLike = ESTree.PropertyDefinition | ESTree.TSPropertySignature;
+
 /**
- * Find the statically known name of a property key
- * @param key The key node of a property signature, property definition or property
+ * Find the statically known name of a property
+ * @param property A property signature or property definition node
  * @returns The name for an Identifier key and the stringified value for a string or numeric
- * Literal key, or null for keys that cannot be resolved statically (computed keys, template
- * literals, etc.)
+ * Literal key, or null for properties whose name cannot be resolved statically (computed keys,
+ * private identifiers, template literals, etc.)
  */
-export const findStaticPropertyName = (key: ESTree.Node): string | null => {
+export const findStaticPropertyName = (property: PropertyLike): string | null => {
+  // NOTE: a computed key is an expression, so its source text is not the property name
+  if (property.computed) return null;
+
+  const key = property.key;
   if (key.type === AST_NODE_TYPES.Identifier) return key.name;
   if (
     key.type === AST_NODE_TYPES.Literal &&

--- a/packages/oxlint/src/rules/no-construct-in-interface.ts
+++ b/packages/oxlint/src/rules/no-construct-in-interface.ts
@@ -30,8 +30,9 @@ export const noConstructInInterface = createRule({
         for (const property of node.body.body) {
           if (property.type !== AST_NODE_TYPES.TSPropertySignature) continue;
 
-          // NOTE: computed keys cannot be resolved statically, so they are skipped
-          const propertyName = findStaticPropertyName(property.key);
+          // NOTE: properties whose name cannot be resolved statically (computed keys, etc.)
+          // are out of scope for this rule
+          const propertyName = findStaticPropertyName(property);
           if (propertyName === null) continue;
 
           const type = parserServices.getTypeAtLocation(property);

--- a/packages/oxlint/src/rules/no-mutable-property-of-props-interface.ts
+++ b/packages/oxlint/src/rules/no-mutable-property-of-props-interface.ts
@@ -36,8 +36,9 @@ export const noMutablePropertyOfPropsInterface = createRule({
           // NOTE: Skip if already readonly
           if (property.readonly) continue;
 
-          // NOTE: computed keys cannot be resolved statically, so they are skipped
-          const propertyName = findStaticPropertyName(property.key);
+          // NOTE: properties whose name cannot be resolved statically (computed keys, etc.)
+          // are out of scope for this rule
+          const propertyName = findStaticPropertyName(property);
           if (propertyName === null) continue;
 
           context.report({

--- a/packages/oxlint/src/rules/require-jsdoc.ts
+++ b/packages/oxlint/src/rules/require-jsdoc.ts
@@ -1,6 +1,7 @@
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findAttachedJSDocComments } from "../core/ast-node/finder/attached-jsdoc-comment";
+import { findStaticPropertyName } from "../core/ast-node/finder/static-property-key";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
 import { createRule } from "../shared/create-rule";
 
@@ -27,12 +28,10 @@ export const requireJSDoc = createRule({
     const checker = parserServices.program.getTypeChecker();
     return {
       TSPropertySignature(node) {
-        if (
-          node.key.type !== AST_NODE_TYPES.Identifier &&
-          node.key.type !== AST_NODE_TYPES.Literal
-        ) {
-          return;
-        }
+        // NOTE: properties whose name cannot be resolved statically (computed keys, etc.)
+        // are out of scope for this rule
+        const propertyName = findStaticPropertyName(node);
+        if (propertyName === null) return;
 
         // NOTE: Check if the parent is an interface
         const grandparent = node.parent?.parent;
@@ -44,8 +43,6 @@ export const requireJSDoc = createRule({
         const comments = findAttachedJSDocComments(context.sourceCode, node);
         if (comments.length > 0) return;
 
-        const propertyName =
-          node.key.type === AST_NODE_TYPES.Identifier ? node.key.name : String(node.key.value);
         context.report({
           node,
           messageId: "missingJSDoc",
@@ -53,13 +50,12 @@ export const requireJSDoc = createRule({
         });
       },
       PropertyDefinition(node) {
-        if (
-          (node.key.type !== AST_NODE_TYPES.Identifier &&
-            node.key.type !== AST_NODE_TYPES.Literal) ||
-          node.parent?.type !== AST_NODE_TYPES.ClassBody
-        ) {
-          return;
-        }
+        if (node.parent?.type !== AST_NODE_TYPES.ClassBody) return;
+
+        // NOTE: properties whose name cannot be resolved statically (computed keys, etc.)
+        // are out of scope for this rule
+        const propertyName = findStaticPropertyName(node);
+        if (propertyName === null) return;
 
         // NOTE: Check if the class extends Construct
         const classDeclaration = node.parent.parent;
@@ -81,8 +77,6 @@ export const requireJSDoc = createRule({
         const comments = findAttachedJSDocComments(context.sourceCode, node);
         if (comments.length > 0) return;
 
-        const propertyName =
-          node.key.type === AST_NODE_TYPES.Identifier ? node.key.name : String(node.key.value);
         context.report({
           node,
           messageId: "missingJSDoc",

--- a/packages/oxlint/src/rules/require-props-default-doc.ts
+++ b/packages/oxlint/src/rules/require-props-default-doc.ts
@@ -4,6 +4,7 @@ import {
   findAttachedJSDocComments,
   hasDefaultTag,
 } from "../core/ast-node/finder/attached-jsdoc-comment";
+import { findStaticPropertyName } from "../core/ast-node/finder/static-property-key";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -27,13 +28,10 @@ export const requirePropsDefaultDoc = createRule({
   create(context) {
     return {
       TSPropertySignature(node) {
-        // NOTE: Only Identifier / Literal (string or numeric) keys are checked.
-        if (
-          node.key.type !== AST_NODE_TYPES.Identifier &&
-          node.key.type !== AST_NODE_TYPES.Literal
-        ) {
-          return;
-        }
+        // NOTE: properties whose name cannot be resolved statically (computed keys, etc.)
+        // are out of scope for this rule
+        const propertyName = findStaticPropertyName(node);
+        if (propertyName === null) return;
 
         // NOTE: Check if the property is optional
         if (!node.optional) return;
@@ -48,8 +46,6 @@ export const requirePropsDefaultDoc = createRule({
         const comments = findAttachedJSDocComments(context.sourceCode, node);
         if (hasDefaultTag(comments)) return;
 
-        const propertyName =
-          node.key.type === AST_NODE_TYPES.Identifier ? node.key.name : String(node.key.value);
         context.report({
           node,
           messageId: "missingDefaultDoc",


### PR DESCRIPTION
### Issue # (if applicable)

N/A — follow-up to #577 (review finding).

### Reason for this change

`findStaticPropertyName` derived a property name from the key node alone, ignoring the member's `computed` flag. A computed key is an expression, so its source text is not the property name: `readonly [key]: Bucket` was reported as `'key'` while the actual property is `"computedIdentifierKey"`. The same held for the inline `Identifier | Literal` key checks in `require-jsdoc` and `require-props-default-doc`. On top of the wrong name, `no-construct-in-interface` reported computed keys under ESLint but not under Oxlint, so the two plugins disagreed on the same file.

Reproduced on `main @ f198926` with the built plugins, against a temporary fixture file linted with rule-isolated configs:

```ts
import { Bucket } from "aws-cdk-lib/aws-s3";

const key = "computedIdentifierKey";

export interface ConstructInInterfaceProps {
  readonly plainBucket: Bucket;
  readonly "quotedBucket": Bucket;
  readonly [key]: Bucket;
  readonly ["computedLiteralBucket"]: Bucket;
}

export interface MutableProps {
  plainValue: string;
  "quotedValue": string;
  [key]: string;
  ["computedLiteralValue"]: string;
}

export interface OptionalDocProps {
  readonly plainOptional?: string;
  readonly "quotedOptional"?: string;
  readonly [key]?: string;
  readonly ["computedLiteralOptional"]?: string;
}
```

Those configs enable only the four rules under test — an ESLint flat config with the `typescript-eslint` parser and `projectService: true`, and an `.oxlintrc.json` with `"jsPlugins": ["oxlint-plugin-awscdk"]` and `"options": { "typeAware": true }`.

```
$ eslint --config repro-tmp/eslint.repro.config.ts repro-tmp/repro.ts

/…/repro.ts
   6:3  error  Interface property 'plainBucket' should not use CDK Construct type 'Bucket'. Consider using an interface or type alias instead            awscdk/no-construct-in-interface
   6:3  error  Property 'plainBucket' should have a JSDoc comment                                                                                        awscdk/require-jsdoc
   7:3  error  Interface property 'quotedBucket' should not use CDK Construct type 'Bucket'. Consider using an interface or type alias instead           awscdk/no-construct-in-interface
   7:3  error  Property 'quotedBucket' should have a JSDoc comment                                                                                       awscdk/require-jsdoc
   8:3  error  Interface property 'key' should not use CDK Construct type 'Bucket'. Consider using an interface or type alias instead                    awscdk/no-construct-in-interface
   8:3  error  Property 'key' should have a JSDoc comment                                                                                                awscdk/require-jsdoc
   9:3  error  Interface property 'computedLiteralBucket' should not use CDK Construct type 'Bucket'. Consider using an interface or type alias instead  awscdk/no-construct-in-interface
   9:3  error  Property 'computedLiteralBucket' should have a JSDoc comment                                                                              awscdk/require-jsdoc
  13:3  error  Property 'plainValue' of Construct Props should be readonly                                                                               awscdk/no-mutable-property-of-props-interface
  13:3  error  Property 'plainValue' should have a JSDoc comment                                                                                         awscdk/require-jsdoc
  14:3  error  Property 'quotedValue' of Construct Props should be readonly                                                                              awscdk/no-mutable-property-of-props-interface
  14:3  error  Property 'quotedValue' should have a JSDoc comment                                                                                        awscdk/require-jsdoc
  15:3  error  Property 'key' of Construct Props should be readonly                                                                                      awscdk/no-mutable-property-of-props-interface
  15:3  error  Property 'key' should have a JSDoc comment                                                                                                awscdk/require-jsdoc
  16:3  error  Property 'computedLiteralValue' of Construct Props should be readonly                                                                     awscdk/no-mutable-property-of-props-interface
  16:3  error  Property 'computedLiteralValue' should have a JSDoc comment                                                                               awscdk/require-jsdoc
  20:3  error  Property 'plainOptional' should have a JSDoc comment                                                                                      awscdk/require-jsdoc
  20:3  error  Optional property 'plainOptional' in Props interface must have @default JSDoc documentation                                               awscdk/require-props-default-doc
  21:3  error  Property 'quotedOptional' should have a JSDoc comment                                                                                     awscdk/require-jsdoc
  21:3  error  Optional property 'quotedOptional' in Props interface must have @default JSDoc documentation                                              awscdk/require-props-default-doc
  22:3  error  Property 'key' should have a JSDoc comment                                                                                                awscdk/require-jsdoc
  22:3  error  Optional property 'key' in Props interface must have @default JSDoc documentation                                                         awscdk/require-props-default-doc
  23:3  error  Property 'computedLiteralOptional' should have a JSDoc comment                                                                            awscdk/require-jsdoc
  23:3  error  Optional property 'computedLiteralOptional' in Props interface must have @default JSDoc documentation                                     awscdk/require-props-default-doc

✖ 24 problems (24 errors, 0 warnings)
  4 errors and 0 warnings potentially fixable with the `--fix` option.
```

```
$ oxlint --format=unix -c repro-tmp/.oxlintrc.json repro-tmp/repro.ts
repro-tmp/repro.ts:6:3: Interface property 'plainBucket' should not use CDK Construct type 'Bucket'. Consider using an interface or type alias instead. [Error/awscdk(no-construct-in-interface)]
repro-tmp/repro.ts:7:3: Interface property 'quotedBucket' should not use CDK Construct type 'Bucket'. Consider using an interface or type alias instead. [Error/awscdk(no-construct-in-interface)]
repro-tmp/repro.ts:6:3: Property 'plainBucket' should have a JSDoc comment. [Error/awscdk(require-jsdoc)]
repro-tmp/repro.ts:7:3: Property 'quotedBucket' should have a JSDoc comment. [Error/awscdk(require-jsdoc)]
repro-tmp/repro.ts:8:3: Property 'key' should have a JSDoc comment. [Error/awscdk(require-jsdoc)]
repro-tmp/repro.ts:9:3: Property 'computedLiteralBucket' should have a JSDoc comment. [Error/awscdk(require-jsdoc)]
repro-tmp/repro.ts:13:3: Property 'plainValue' of Construct Props should be readonly. [Error/awscdk(no-mutable-property-of-props-interface)]
repro-tmp/repro.ts:14:3: Property 'quotedValue' of Construct Props should be readonly. [Error/awscdk(no-mutable-property-of-props-interface)]
repro-tmp/repro.ts:15:3: Property 'key' of Construct Props should be readonly. [Error/awscdk(no-mutable-property-of-props-interface)]
repro-tmp/repro.ts:16:3: Property 'computedLiteralValue' of Construct Props should be readonly. [Error/awscdk(no-mutable-property-of-props-interface)]
repro-tmp/repro.ts:13:3: Property 'plainValue' should have a JSDoc comment. [Error/awscdk(require-jsdoc)]
repro-tmp/repro.ts:14:3: Property 'quotedValue' should have a JSDoc comment. [Error/awscdk(require-jsdoc)]
repro-tmp/repro.ts:15:3: Property 'key' should have a JSDoc comment. [Error/awscdk(require-jsdoc)]
repro-tmp/repro.ts:16:3: Property 'computedLiteralValue' should have a JSDoc comment. [Error/awscdk(require-jsdoc)]
repro-tmp/repro.ts:20:3: Property 'plainOptional' should have a JSDoc comment. [Error/awscdk(require-jsdoc)]
repro-tmp/repro.ts:20:3: Optional property 'plainOptional' in Props interface must have @default JSDoc documentation [Error/awscdk(require-props-default-doc)]
repro-tmp/repro.ts:21:3: Property 'quotedOptional' should have a JSDoc comment. [Error/awscdk(require-jsdoc)]
repro-tmp/repro.ts:21:3: Optional property 'quotedOptional' in Props interface must have @default JSDoc documentation [Error/awscdk(require-props-default-doc)]
repro-tmp/repro.ts:22:3: Property 'key' should have a JSDoc comment. [Error/awscdk(require-jsdoc)]
repro-tmp/repro.ts:22:3: Optional property 'key' in Props interface must have @default JSDoc documentation [Error/awscdk(require-props-default-doc)]
repro-tmp/repro.ts:23:3: Property 'computedLiteralOptional' should have a JSDoc comment. [Error/awscdk(require-jsdoc)]
repro-tmp/repro.ts:23:3: Optional property 'computedLiteralOptional' in Props interface must have @default JSDoc documentation [Error/awscdk(require-props-default-doc)]

22 problems
```

Lines 8, 15 and 22 are all `[key]`, reported as `'key'` although the property is `"computedIdentifierKey"`. Lines 8 and 9 also show the ESLint/Oxlint divergence for `no-construct-in-interface`.

### Description of changes

- `findStaticPropertyName` now takes the member node instead of its key, and returns `null` when the member is `computed`. Computed keys are skipped by every rule that reports a property by name, which is what the existing `NOTE:` comments already claimed and what Oxlint's `no-construct-in-interface` already did.
- `require-jsdoc` and `require-props-default-doc` had the same defect in their own inline key checks, so they now use the shared finder as well.

After the change both plugins report the same 12 problems on the fixture above — only the plain and quoted keys, none of the computed ones.

### Description of how you validated changes

- Computed identifier key and computed string literal key cases added to all four rules' suites in both packages, alongside the existing plain and quoted key cases that must keep reporting. 16 of these 18 cases fail against the unpatched source; the remaining two pin the Oxlint `no-construct-in-interface` behaviour that ESLint now matches.
- A numeric literal key case (`1`, reported as `'1'`) added to all four suites in both packages, including the autofix output for `no-mutable-property-of-props-interface`. These are regression guards for behaviour this PR does not change: they pass both before and after it.
- `vp check`, `vp test --run`, and `vp run -r pack && bash scripts/integration-test.sh` (3× SUCCESS at 43 errors).
- Rebased onto `main` at `4934766` (after #585, #586 and #592) and re-verified on corsa-oxlint 1.13.1 / oxlint 1.81.0: `vp check` passes and `vp test --run` passes (34 files, 798 tests); CI is green on the rebased head. The rebase conflicted only in `require-jsdoc.test.ts`, where #585 appended an invalid case at the same spot as the numeric literal key case; both are kept as separate entries in both packages.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_



