### PR TITLE
perf: bump corsa-oxlint to 1.14.0 and cut corsa type queries in the Construct rules

### DIFF
--- a/packages/eslint/src/__tests__/prefer-grants-property.test.ts
+++ b/packages/eslint/src/__tests__/prefer-grants-property.test.ts
@@ -412,8 +412,6 @@ ruleTester.run("prefer-grants-property", preferGrantsProperty, {
       errors: [{ messageId: "useGrantsProperty" }],
     },
     // WHEN: the receiver is an array element
-    // NOTE: the Oxlint plugin skips this receiver on corsa-oxlint 1.13.1, which resolves an array
-    // element to the array type
     {
       code: `
       class Construct {}

--- a/packages/eslint/src/__tests__/require-passing-this.test.ts
+++ b/packages/eslint/src/__tests__/require-passing-this.test.ts
@@ -234,6 +234,47 @@ ruleTester.run("require-passing-this", requirePassingThis, {
     },
   ],
   invalid: [
+    // WHEN: a Construct and a plain class are instantiated with `scope` in the same file
+    // NOTE: only the Construct is reported, which pins that the two classes are judged separately
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class PlainClass {
+        constructor(scope: Construct, id: string) {}
+      }
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new PlainClass(scope, "PlainId");
+          new SampleConstruct(scope, "ValidId");
+        }
+      }
+      `,
+      errors: [{ messageId: "missingPassingThis" }],
+      output: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class PlainClass {
+        constructor(scope: Construct, id: string) {}
+      }
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new PlainClass(scope, "PlainId");
+          new SampleConstruct(this, "ValidId");
+        }
+      }
+      `,
+    },
     // WHEN: passing 'scope' variable
     {
       code: `

--- a/packages/eslint/src/rules/no-construct-stack-suffix.ts
+++ b/packages/eslint/src/rules/no-construct-stack-suffix.ts
@@ -64,10 +64,10 @@ export const noConstructStackSuffix = createRule({
 
     return {
       NewExpression(node) {
+        if (node.arguments.length < 2) return;
+
         const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructOrStackType(type) || node.arguments.length < 2) {
-          return;
-        }
+        if (!isConstructOrStackType(type)) return;
 
         const calleeType = parserServices.getTypeAtLocation(node.callee);
         const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);

--- a/packages/eslint/src/rules/no-variable-construct-id.ts
+++ b/packages/eslint/src/rules/no-variable-construct-id.ts
@@ -31,9 +31,10 @@ export const noVariableConstructId = createRule({
     const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
-        const type = parserServices.getTypeAtLocation(node);
+        if (node.arguments.length < 2) return;
 
-        if (!isConstructTypeIgnoringSubclasses(type) || node.arguments.length < 2) return;
+        const type = parserServices.getTypeAtLocation(node);
+        if (!isConstructTypeIgnoringSubclasses(type)) return;
 
         // NOTE: Skip when inside a class that is not Construct/Stack
         const enclosingClass = findEnclosingClass(node);

--- a/packages/eslint/src/rules/pascal-case-construct-id.ts
+++ b/packages/eslint/src/rules/pascal-case-construct-id.ts
@@ -42,10 +42,10 @@ export const pascalCaseConstructId = createRule({
     const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
+        if (node.arguments.length < 2) return;
+
         const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructOrStackType(type) || node.arguments.length < 2) {
-          return;
-        }
+        if (!isConstructOrStackType(type)) return;
 
         const calleeType = parserServices.getTypeAtLocation(node.callee);
         const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);

--- a/packages/eslint/src/rules/prevent-construct-id-collision.ts
+++ b/packages/eslint/src/rules/prevent-construct-id-collision.ts
@@ -30,9 +30,10 @@ export const preventConstructIdCollision = createRule({
     const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
-        const type = parserServices.getTypeAtLocation(node);
+        if (node.arguments.length < 2) return;
 
-        if (!isConstructTypeIgnoringSubclasses(type) || node.arguments.length < 2) return;
+        const type = parserServices.getTypeAtLocation(node);
+        if (!isConstructTypeIgnoringSubclasses(type)) return;
 
         const calleeType = parserServices.getTypeAtLocation(node.callee);
         const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);

--- a/packages/eslint/src/rules/require-passing-this.ts
+++ b/packages/eslint/src/rules/require-passing-this.ts
@@ -53,20 +53,21 @@ export const requirePassingThis = createRule({
     const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
-        const type = parserServices.getTypeAtLocation(node);
+        if (!node.arguments.length) return;
 
-        if (!isConstructTypeIgnoringSubclasses(type) || !node.arguments.length) return;
+        const argument = node.arguments[0];
+
+        // NOTE: If the first argument is already `this`, it's valid
+        if (argument.type === AST_NODE_TYPES.ThisExpression) return;
+
+        const type = parserServices.getTypeAtLocation(node);
+        if (!isConstructTypeIgnoringSubclasses(type)) return;
 
         // NOTE: Only flag when inside a Construct/Stack class where `this` is available
         const enclosingClass = findEnclosingClass(node);
         if (!enclosingClass) return;
         const enclosingClassType = parserServices.getTypeAtLocation(enclosingClass);
         if (!isConstructOrStackType(enclosingClassType)) return;
-
-        const argument = node.arguments[0];
-
-        // NOTE: If the first argument is already `this`, it's valid
-        if (argument.type === AST_NODE_TYPES.ThisExpression) return;
 
         // NOTE: If the first argument is not `scope`, it's valid
         const calleeType = parserServices.getTypeAtLocation(node.callee);

--- a/packages/oxlint/package.json
+++ b/packages/oxlint/package.json
@@ -48,7 +48,7 @@
     "test": "vp test --run"
   },
   "dependencies": {
-    "corsa-oxlint": "1.13.1",
+    "corsa-oxlint": "1.14.0",
     "oxlint-tsgolint": "^7.0.2001",
     "typescript": "^7.0.2"
   },

--- a/packages/oxlint/src/__tests__/prefer-grants-property.test.ts
+++ b/packages/oxlint/src/__tests__/prefer-grants-property.test.ts
@@ -162,22 +162,6 @@ ruleTester.run("prefer-grants-property", preferGrantsProperty, {
       registry["x"].grantPublish();
       `,
     },
-    // NOTE: corsa-oxlint 1.13.1 resolves an array element to the array type, so this receiver is
-    // skipped. A runtime that resolves it correctly reports it, as the ESLint plugin already does.
-    {
-      code: `
-      class Construct {}
-      class TopicGrants {
-        publish() {}
-      }
-      class Topic extends Construct {
-        grants: TopicGrants = new TopicGrants();
-        grantPublish() {}
-      }
-      declare const topics: Topic[];
-      topics[0].grantPublish();
-      `,
-    },
     // NOTE: the member and the object resolve to the same type here, so the receiver is skipped.
     // The ESLint plugin reports this case.
     {
@@ -393,6 +377,22 @@ ruleTester.run("prefer-grants-property", preferGrantsProperty, {
       }
       const maybe = (): Topic | undefined => new Topic();
       maybe()?.grantPublish();
+      `,
+      errors: [{ messageId: "useGrantsProperty" }],
+    },
+    // WHEN: the receiver is an array element
+    {
+      code: `
+      class Construct {}
+      class TopicGrants {
+        publish() {}
+      }
+      class Topic extends Construct {
+        grants: TopicGrants = new TopicGrants();
+        grantPublish() {}
+      }
+      declare const topics: Topic[];
+      topics[0].grantPublish();
       `,
       errors: [{ messageId: "useGrantsProperty" }],
     },

--- a/packages/oxlint/src/__tests__/require-passing-this.test.ts
+++ b/packages/oxlint/src/__tests__/require-passing-this.test.ts
@@ -192,6 +192,47 @@ ruleTester.run("require-passing-this", requirePassingThis, {
     },
   ],
   invalid: [
+    // WHEN: a Construct and a plain class are instantiated with `scope` in the same file
+    // NOTE: only the Construct is reported, which pins that the two classes are judged separately
+    {
+      code: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class PlainClass {
+        constructor(scope: Construct, id: string) {}
+      }
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new PlainClass(scope, "PlainId");
+          new SampleConstruct(scope, "ValidId");
+        }
+      }
+      `,
+      errors: [{ messageId: "missingPassingThis" }],
+      output: `
+      class Construct {}
+      class SampleConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+        }
+      }
+      class PlainClass {
+        constructor(scope: Construct, id: string) {}
+      }
+      class TestConstruct extends Construct {
+        constructor(scope: Construct, id: string) {
+          super(scope, id);
+          new PlainClass(scope, "PlainId");
+          new SampleConstruct(this, "ValidId");
+        }
+      }
+      `,
+    },
     {
       code: `
       class Construct {}

--- a/packages/oxlint/src/core/ts-type/checker/is-extends-target-super-class.ts
+++ b/packages/oxlint/src/core/ts-type/checker/is-extends-target-super-class.ts
@@ -1,5 +1,9 @@
 import type { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
 
+import { createTypeQueryMemo } from "../memo/type-query-memo";
+
+const memoizeExtendsResult = createTypeQueryMemo<boolean>();
+
 /**
  * Check if the type extends one of the target super classes (recursively walking the base type chain).
  * @param type - The type to check
@@ -16,6 +20,22 @@ export const isExtendsFromTargetSuperClass = (
 ): boolean => {
   if (!type) return false;
 
+  // NOTE: The walk asks corsa for the symbol and the base types of every level, and rules run it
+  // once per AST node even though a file mentions only a handful of distinct types. The answer
+  // depends on nothing but the arguments, so it is resolved once per type and question.
+  return memoizeExtendsResult(
+    checker,
+    `${type.id}|${targetSuperClasses.join(",")}|${ignoredClasses.join(",")}`,
+    () => walkBaseTypes(type, checker, targetSuperClasses, ignoredClasses),
+  );
+};
+
+const walkBaseTypes = (
+  type: CorsaType,
+  checker: CorsaTypeCheckerShape,
+  targetSuperClasses: readonly string[],
+  ignoredClasses: readonly string[],
+): boolean => {
   // NOTE: A union / intersection type is not a class of its own, so it never extends a super class.
   // Callers that want to look inside it use findTypeOfCdkConstruct instead.
   if (checker.isUnionType(type) || checker.isIntersectionType(type)) return false;

--- a/packages/oxlint/src/core/ts-type/finder/constructor-property-name.ts
+++ b/packages/oxlint/src/core/ts-type/finder/constructor-property-name.ts
@@ -2,6 +2,10 @@ import type { CorsaType, CorsaTypeCheckerShape } from "corsa-oxlint";
 
 import { SignatureKind } from "corsa-oxlint";
 
+import { createTypeQueryMemo } from "../memo/type-query-memo";
+
+const memoizePropertyNames = createTypeQueryMemo<string[]>();
+
 /**
  * Parses type to get the property names of the class constructor.
  * @returns The property names of the class constructor.
@@ -11,6 +15,14 @@ export const findConstructorPropertyNames = (
   checker: CorsaTypeCheckerShape,
 ): string[] => {
   if (!type) return [];
+
+  // NOTE: Resolving a construct signature is one of the most expensive corsa queries, and the
+  // construct id rules ask for it once per `new` expression even though a file instantiates only a
+  // handful of distinct classes.
+  return memoizePropertyNames(checker, type.id, () => resolvePropertyNames(type, checker));
+};
+
+const resolvePropertyNames = (type: CorsaType, checker: CorsaTypeCheckerShape): string[] => {
   const signature = checker.getSignaturesOfType(type, SignatureKind.Construct)[0];
   if (!signature?.parameterSymbols) return [];
 

--- a/packages/oxlint/src/core/ts-type/finder/type-at-location.ts
+++ b/packages/oxlint/src/core/ts-type/finder/type-at-location.ts
@@ -1,0 +1,41 @@
+import type { CorsaType, ParserServices } from "corsa-oxlint";
+
+type TypedNode = Parameters<ParserServices["getTypeAtLocation"]>[0];
+
+type ResolvedType = { readonly value: CorsaType | undefined };
+
+const typesByServices = new WeakMap<ParserServices, WeakMap<TypedNode, ResolvedType>>();
+
+/**
+ * Resolves the type of an AST node through corsa, reusing the answer when the same node is asked
+ * for again through the same parser services.
+ *
+ * NOTE: a resolution corsa cannot serve from its own per-snapshot caches costs a transport round
+ * trip, and rules re-resolve the same node repeatedly (the enclosing class of each `new` expression,
+ * for example). The memo is keyed on the parser services, which oxlint builds per `create()` call,
+ * so it is scoped to a single rule instance on a single file and never outlives the snapshot the
+ * types were resolved from. Keying on the AST node object lets entries disappear together with the
+ * parsed file.
+ * @param node - The AST node to resolve
+ * @param parserServices - The corsa-oxlint parser services
+ * @returns The type of the node, or undefined when it cannot be resolved
+ */
+export const findTypeAtLocation = (
+  node: TypedNode,
+  parserServices: ParserServices,
+): CorsaType | undefined => {
+  const types = findTypes(parserServices);
+  const resolved = types.get(node);
+  if (resolved) return resolved.value;
+  const value = parserServices.getTypeAtLocation(node);
+  types.set(node, { value });
+  return value;
+};
+
+const findTypes = (parserServices: ParserServices): WeakMap<TypedNode, ResolvedType> => {
+  const types = typesByServices.get(parserServices);
+  if (types) return types;
+  const created = new WeakMap<TypedNode, ResolvedType>();
+  typesByServices.set(parserServices, created);
+  return created;
+};

--- a/packages/oxlint/src/core/ts-type/memo/type-query-memo.ts
+++ b/packages/oxlint/src/core/ts-type/memo/type-query-memo.ts
@@ -1,0 +1,45 @@
+import type { CorsaTypeCheckerShape } from "corsa-oxlint";
+
+/**
+ * Resolves a value once per key for the lifetime of the checker it is asked through.
+ */
+export type TypeQueryMemo<Result> = (
+  checker: CorsaTypeCheckerShape,
+  key: string,
+  resolve: () => Result,
+) => Result;
+
+type MemoEntry<Result> = { readonly value: Result };
+
+/**
+ * Creates a memo for a single pure type query.
+ *
+ * NOTE: corsa answers checker queries over the transport to the TypeScript process. Its session
+ * serves some of them from its own per-snapshot caches, but the rest cost a round trip, and asking
+ * the same question once per AST node pays that repeatedly even when the answer depends only on the
+ * type. `create()` runs once per rule per file and builds one checker, so keying the memo on that
+ * checker scopes it to a single rule instance on a single file: never longer than the snapshot the
+ * types were resolved from, and empty again on the next `create()` call. Keys are built from
+ * `CorsaType.id`, the same identity corsa caches base types and symbols by.
+ * @returns A query wrapper that resolves each key at most once per checker
+ */
+export const createTypeQueryMemo = <Result>(): TypeQueryMemo<Result> => {
+  const entriesByChecker = new WeakMap<CorsaTypeCheckerShape, Map<string, MemoEntry<Result>>>();
+
+  const findEntries = (checker: CorsaTypeCheckerShape): Map<string, MemoEntry<Result>> => {
+    const entries = entriesByChecker.get(checker);
+    if (entries) return entries;
+    const created = new Map<string, MemoEntry<Result>>();
+    entriesByChecker.set(checker, created);
+    return created;
+  };
+
+  return (checker, key, resolve) => {
+    const entries = findEntries(checker);
+    const entry = entries.get(key);
+    if (entry) return entry.value;
+    const value = resolve();
+    entries.set(key, { value });
+    return value;
+  };
+};

--- a/packages/oxlint/src/rules/construct-constructor-property.ts
+++ b/packages/oxlint/src/rules/construct-constructor-property.ts
@@ -1,4 +1,4 @@
-import type { ESTree, ParserServices, RuleContext } from "corsa-oxlint";
+import type { CorsaTypeCheckerShape, ESTree, ParserServices, RuleContext } from "corsa-oxlint";
 
 import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
@@ -6,6 +6,7 @@ import { findConstructor } from "../core/ast-node/finder/constructor";
 import { findConstructorParamIdentifier } from "../core/ast-node/finder/constructor-param-identifier";
 import { isAppType } from "../core/cdk-construct/type-checker/is-app";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { findTypeAtLocation } from "../core/ts-type/finder/type-at-location";
 import { createRule } from "../shared/create-rule";
 
 type ConstructorParam =
@@ -46,7 +47,7 @@ export const constructConstructorProperty = createRule({
     const checker = parserServices.program.getTypeChecker();
     return {
       ClassDeclaration(node) {
-        const type = parserServices.getTypeAtLocation(node);
+        const type = findTypeAtLocation(node, parserServices);
         // NOTE: App and its subclasses take `(props)` instead of `(scope, id)`,
         // so they can never satisfy this rule
         if (!isConstructType(type, checker) || isAppType(type, checker)) return;
@@ -56,7 +57,7 @@ export const constructConstructorProperty = createRule({
 
         const params = checkNumOfConstructorProperty(constructor, context);
         if (params) {
-          checkFirstParamIsScope(params[0], context, parserServices);
+          checkFirstParamIsScope(params[0], context, parserServices, checker);
           checkSecondParamIsId(params[1], context);
           checkThirdParamIsProps(params[2], context);
         }
@@ -91,6 +92,7 @@ const checkFirstParamIsScope = (
   firstParam: ConstructorProperties[0],
   context: RuleContext,
   parserServices: ParserServices,
+  checker: CorsaTypeCheckerShape,
 ) => {
   const binding = findConstructorParamIdentifier(firstParam);
   if (!binding || binding.name !== "scope") {
@@ -98,13 +100,7 @@ const checkFirstParamIsScope = (
       node: firstParam,
       messageId: "invalidConstructorProperty",
     });
-  } else if (
-    !isConstructType(
-      parserServices.getTypeAtLocation(binding),
-      parserServices.program.getTypeChecker(),
-      [],
-    )
-  ) {
+  } else if (!isConstructType(findTypeAtLocation(binding, parserServices), checker, [])) {
     context.report({
       node: firstParam,
       messageId: "invalidConstructorType",

--- a/packages/oxlint/src/rules/no-construct-in-interface.ts
+++ b/packages/oxlint/src/rules/no-construct-in-interface.ts
@@ -2,6 +2,7 @@ import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 
 import { findStaticPropertyName } from "../core/ast-node/finder/static-property-key";
 import { findTypeOfCdkConstruct } from "../core/cdk-construct/type-finder";
+import { findTypeAtLocation } from "../core/ts-type/finder/type-at-location";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -35,7 +36,7 @@ export const noConstructInInterface = createRule({
           const propertyName = findStaticPropertyName(property);
           if (propertyName === null) continue;
 
-          const type = parserServices.getTypeAtLocation(property);
+          const type = findTypeAtLocation(property, parserServices);
           const result = findTypeOfCdkConstruct(type, checker);
 
           if (result) {

--- a/packages/oxlint/src/rules/no-construct-in-public-property-of-construct.ts
+++ b/packages/oxlint/src/rules/no-construct-in-public-property-of-construct.ts
@@ -1,4 +1,4 @@
-import type { ParserServices, RuleContext } from "corsa-oxlint";
+import type { CorsaTypeCheckerShape, ParserServices, RuleContext } from "corsa-oxlint";
 
 import { ESLintUtils } from "corsa-oxlint";
 
@@ -8,6 +8,7 @@ import {
 } from "../core/ast-node/finder/public-property";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findTypeOfCdkConstruct } from "../core/cdk-construct/type-finder";
+import { findTypeAtLocation } from "../core/ts-type/finder/type-at-location";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -33,11 +34,11 @@ export const noConstructInPublicPropertyOfConstruct = createRule({
     const checker = parserServices.program.getTypeChecker();
     return {
       ClassDeclaration(node) {
-        const type = parserServices.getTypeAtLocation(node);
+        const type = findTypeAtLocation(node, parserServices);
         if (!isConstructOrStackType(type, checker)) return;
         const publicProperties = findPublicPropertiesInClass(node);
         for (const publicProperty of publicProperties) {
-          validatePublicProperty(publicProperty, context, parserServices);
+          validatePublicProperty(publicProperty, context, parserServices, checker);
         }
       },
     };
@@ -48,6 +49,7 @@ const validatePublicProperty = (
   publicProperty: PublicProperty,
   context: RuleContext,
   parserServices: ParserServices,
+  checker: CorsaTypeCheckerShape,
 ) => {
   // Only inspect properties that have an explicit type annotation.
   // Inferring the type from an initializer is out of scope for this rule.
@@ -56,8 +58,7 @@ const validatePublicProperty = (
   // NOTE: The declared type is read from the declaration's identifier rather than from the
   // property node, because the identifier resolves consistently for every declaration form
   // (`!`, `?`, initializer) in both type checkers.
-  const type = parserServices.getTypeAtLocation(publicProperty.node.key);
-  const checker = parserServices.program.getTypeChecker();
+  const type = findTypeAtLocation(publicProperty.node.key, parserServices);
   const constructType = findTypeOfCdkConstruct(type, checker);
   if (constructType) {
     const typeName = checker.getSymbolOfType(constructType)?.name ?? "";

--- a/packages/oxlint/src/rules/no-construct-stack-suffix.ts
+++ b/packages/oxlint/src/rules/no-construct-stack-suffix.ts
@@ -5,6 +5,7 @@ import { ESLintUtils } from "corsa-oxlint";
 import { findConstructIdString } from "../core/ast-node/finder/construct-id-string";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
+import { findTypeAtLocation } from "../core/ts-type/finder/type-at-location";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
 import { createRule } from "../shared/create-rule";
 
@@ -63,12 +64,12 @@ export const noConstructStackSuffix = createRule({
 
     return {
       NewExpression(node) {
-        const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructOrStackType(type, checker) || node.arguments.length < 2) {
-          return;
-        }
+        if (node.arguments.length < 2) return;
 
-        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const type = findTypeAtLocation(node, parserServices);
+        if (!isConstructOrStackType(type, checker)) return;
+
+        const calleeType = findTypeAtLocation(node.callee, parserServices);
         const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[1] !== "id") return;
 

--- a/packages/oxlint/src/rules/no-mutable-public-property-of-construct.ts
+++ b/packages/oxlint/src/rules/no-mutable-public-property-of-construct.ts
@@ -7,6 +7,7 @@ import {
   PublicProperty,
 } from "../core/ast-node/finder/public-property";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
+import { findTypeAtLocation } from "../core/ts-type/finder/type-at-location";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -34,7 +35,7 @@ export const noMutablePublicPropertyOfConstruct = createRule({
 
     return {
       ClassDeclaration(node) {
-        const type = parserServices.getTypeAtLocation(node);
+        const type = findTypeAtLocation(node, parserServices);
         if (!isConstructOrStackType(type, checker)) return;
 
         const publicProperties = findPublicPropertiesInClass(node);

--- a/packages/oxlint/src/rules/no-parent-name-construct-id-match.ts
+++ b/packages/oxlint/src/rules/no-parent-name-construct-id-match.ts
@@ -7,6 +7,7 @@ import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isInsideConstructorOrMethod } from "../core/ast-node/finder/enclosing-method";
 import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
+import { findTypeAtLocation } from "../core/ts-type/finder/type-at-location";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
 import { createRule } from "../shared/create-rule";
 
@@ -56,7 +57,7 @@ export const noParentNameConstructIdMatch = createRule({
       NewExpression(node) {
         if (node.arguments.length < 2) return;
 
-        const type = parserServices.getTypeAtLocation(node);
+        const type = findTypeAtLocation(node, parserServices);
         if (!isConstructTypeIgnoringSubclasses(type, checker)) return;
 
         // NOTE: nested closures do not have a stable "parent class" relationship
@@ -65,7 +66,7 @@ export const noParentNameConstructIdMatch = createRule({
         const enclosingClass = findEnclosingClass(node);
         if (!enclosingClass) return;
 
-        const enclosingClassType = parserServices.getTypeAtLocation(enclosingClass);
+        const enclosingClassType = findTypeAtLocation(enclosingClass, parserServices);
         if (!isConstructOrStackType(enclosingClassType, checker)) return;
 
         const parentClassName = enclosingClass.id?.name;

--- a/packages/oxlint/src/rules/no-unused-props/index.ts
+++ b/packages/oxlint/src/rules/no-unused-props/index.ts
@@ -6,6 +6,7 @@ import { findConstructor } from "../../core/ast-node/finder/constructor";
 import { findConstructorParamIdentifier } from "../../core/ast-node/finder/constructor-param-identifier";
 import { isConstructType } from "../../core/cdk-construct/type-checker/is-construct";
 import { findNonNullableType } from "../../core/ts-type/finder/non-nullable-type";
+import { findTypeAtLocation } from "../../core/ts-type/finder/type-at-location";
 import { createRule } from "../../shared/create-rule";
 import { PropsUsageAnalyzer } from "./props-usage-analyzer";
 import { IPropsUsageTracker, PropsUsageTracker } from "./props-usage-tracker";
@@ -36,7 +37,7 @@ export const noUnusedProps = createRule({
       ClassDeclaration(node) {
         if (node.abstract) return;
 
-        const type = parserServices.getTypeAtLocation(node);
+        const type = findTypeAtLocation(node, parserServices);
         if (!isConstructType(type, checker)) return;
 
         const constructor = findConstructor(node);
@@ -75,7 +76,7 @@ const getPropsParam = (
   const identifier = findConstructorParamIdentifier(propsParam);
   if (!identifier) return null;
 
-  const type = parserServices.getTypeAtLocation(identifier);
+  const type = findTypeAtLocation(identifier, parserServices);
   if (!type) return null;
 
   return {

--- a/packages/oxlint/src/rules/no-variable-construct-id.ts
+++ b/packages/oxlint/src/rules/no-variable-construct-id.ts
@@ -6,6 +6,7 @@ import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
+import { findTypeAtLocation } from "../core/ts-type/finder/type-at-location";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -30,18 +31,19 @@ export const noVariableConstructId = createRule({
     const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
-        const type = parserServices.getTypeAtLocation(node);
+        if (node.arguments.length < 2) return;
 
-        if (!isConstructTypeIgnoringSubclasses(type, checker) || node.arguments.length < 2) return;
+        const type = findTypeAtLocation(node, parserServices);
+        if (!isConstructTypeIgnoringSubclasses(type, checker)) return;
 
         // NOTE: Skip when inside a class that is not Construct/Stack
         const enclosingClass = findEnclosingClass(node);
         const enclosingClassType = enclosingClass
-          ? parserServices.getTypeAtLocation(enclosingClass)
+          ? findTypeAtLocation(enclosingClass, parserServices)
           : undefined;
         if (enclosingClassType && !isConstructOrStackType(enclosingClassType, checker)) return;
 
-        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const calleeType = findTypeAtLocation(node.callee, parserServices);
         const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[1] !== "id") return;
 

--- a/packages/oxlint/src/rules/pascal-case-construct-id.ts
+++ b/packages/oxlint/src/rules/pascal-case-construct-id.ts
@@ -6,6 +6,7 @@ import { findConstructIdString } from "../core/ast-node/finder/construct-id-stri
 import { findSiblingConstructIdStrings } from "../core/ast-node/finder/sibling-construct-id-strings";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
+import { findTypeAtLocation } from "../core/ts-type/finder/type-at-location";
 import { toPascalCase } from "../shared/converter/to-pascal-case";
 import { createRule } from "../shared/create-rule";
 
@@ -40,12 +41,12 @@ export const pascalCaseConstructId = createRule({
     const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
-        const type = parserServices.getTypeAtLocation(node);
-        if (!isConstructOrStackType(type, checker) || node.arguments.length < 2) {
-          return;
-        }
+        if (node.arguments.length < 2) return;
 
-        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const type = findTypeAtLocation(node, parserServices);
+        if (!isConstructOrStackType(type, checker)) return;
+
+        const calleeType = findTypeAtLocation(node.callee, parserServices);
         const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[1] !== "id") return;
 

--- a/packages/oxlint/src/rules/prevent-construct-id-collision.ts
+++ b/packages/oxlint/src/rules/prevent-construct-id-collision.ts
@@ -6,6 +6,7 @@ import { isDeclaredInEnclosingBlocks } from "../core/ast-node/finder/declared-in
 import { findEnclosingLoopBody } from "../core/ast-node/finder/enclosing-loop-body";
 import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
+import { findTypeAtLocation } from "../core/ts-type/finder/type-at-location";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -33,11 +34,12 @@ export const preventConstructIdCollision = createRule({
     const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
-        const type = parserServices.getTypeAtLocation(node);
+        if (node.arguments.length < 2) return;
 
-        if (!isConstructTypeIgnoringSubclasses(type, checker) || node.arguments.length < 2) return;
+        const type = findTypeAtLocation(node, parserServices);
+        if (!isConstructTypeIgnoringSubclasses(type, checker)) return;
 
-        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const calleeType = findTypeAtLocation(node.callee, parserServices);
         const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[1] !== "id") return;
 

--- a/packages/oxlint/src/rules/props-name-convention.ts
+++ b/packages/oxlint/src/rules/props-name-convention.ts
@@ -3,6 +3,7 @@ import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 import { findConstructor } from "../core/ast-node/finder/constructor";
 import { findConstructorParamIdentifier } from "../core/ast-node/finder/constructor-param-identifier";
 import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
+import { findTypeAtLocation } from "../core/ts-type/finder/type-at-location";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -30,7 +31,7 @@ export const propsNameConvention = createRule({
       ClassDeclaration(node) {
         if (!node.id || !node.superClass) return;
 
-        const type = parserServices.getTypeAtLocation(node.superClass);
+        const type = findTypeAtLocation(node.superClass, parserServices);
         if (!isConstructTypeIgnoringSubclasses(type, checker)) return;
 
         // NOTE: check constructor parameter

--- a/packages/oxlint/src/rules/require-jsdoc.ts
+++ b/packages/oxlint/src/rules/require-jsdoc.ts
@@ -3,6 +3,7 @@ import { AST_NODE_TYPES, ESLintUtils } from "corsa-oxlint";
 import { findAttachedJSDocComments } from "../core/ast-node/finder/attached-jsdoc-comment";
 import { findStaticPropertyName } from "../core/ast-node/finder/static-property-key";
 import { isConstructType } from "../core/cdk-construct/type-checker/is-construct";
+import { findTypeAtLocation } from "../core/ts-type/finder/type-at-location";
 import { createRule } from "../shared/create-rule";
 
 /**
@@ -68,7 +69,7 @@ export const requireJSDoc = createRule({
         }
 
         // NOTE: Check if the class extends Construct and the property is public
-        const classType = parserServices.getTypeAtLocation(classDeclaration);
+        const classType = findTypeAtLocation(classDeclaration, parserServices);
         const accessibility = node.accessibility ?? "public";
         if (!isConstructType(classType, checker) || accessibility !== "public") {
           return;

--- a/packages/oxlint/src/rules/require-passing-this.ts
+++ b/packages/oxlint/src/rules/require-passing-this.ts
@@ -4,6 +4,7 @@ import { findEnclosingClass } from "../core/ast-node/finder/enclosing-class";
 import { isConstructTypeIgnoringSubclasses } from "../core/cdk-construct/type-checker/is-construct";
 import { isConstructOrStackType } from "../core/cdk-construct/type-checker/is-construct-or-stack";
 import { findConstructorPropertyNames } from "../core/ts-type/finder/constructor-property-name";
+import { findTypeAtLocation } from "../core/ts-type/finder/type-at-location";
 import { createRule } from "../shared/create-rule";
 
 type Option = {
@@ -50,23 +51,24 @@ export const requirePassingThis = createRule({
     const checker = parserServices.program.getTypeChecker();
     return {
       NewExpression(node) {
-        const type = parserServices.getTypeAtLocation(node);
-
-        if (!isConstructTypeIgnoringSubclasses(type, checker) || !node.arguments.length) return;
-
-        // NOTE: Only flag when inside a Construct/Stack class where `this` is available
-        const enclosingClass = findEnclosingClass(node);
-        if (!enclosingClass) return;
-        const enclosingClassType = parserServices.getTypeAtLocation(enclosingClass);
-        if (!isConstructOrStackType(enclosingClassType, checker)) return;
+        if (!node.arguments.length) return;
 
         const argument = node.arguments[0];
 
         // NOTE: If the first argument is already `this`, it's valid
         if (argument.type === AST_NODE_TYPES.ThisExpression) return;
 
+        const type = findTypeAtLocation(node, parserServices);
+        if (!isConstructTypeIgnoringSubclasses(type, checker)) return;
+
+        // NOTE: Only flag when inside a Construct/Stack class where `this` is available
+        const enclosingClass = findEnclosingClass(node);
+        if (!enclosingClass) return;
+        const enclosingClassType = findTypeAtLocation(enclosingClass, parserServices);
+        if (!isConstructOrStackType(enclosingClassType, checker)) return;
+
         // NOTE: If the first argument is not `scope`, it's valid
-        const calleeType = parserServices.getTypeAtLocation(node.callee);
+        const calleeType = findTypeAtLocation(node.callee, parserServices);
         const constructorPropertyNames = findConstructorPropertyNames(calleeType, checker);
         if (constructorPropertyNames[0] !== "scope") return;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ importers:
   packages/oxlint:
     dependencies:
       corsa-oxlint:
-        specifier: 1.13.1
-        version: 1.13.1(@oxlint/plugins@1.81.0)(oxlint@1.81.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.3.0(@types/node@24.10.15)(jiti@2.6.1)(typescript@7.0.2)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(yaml@2.8.1)))
+        specifier: 1.14.0
+        version: 1.14.0(@oxlint/plugins@1.81.0)(oxlint@1.81.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.3.0(@types/node@24.10.15)(jiti@2.6.1)(typescript@7.0.2)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(yaml@2.8.1)))
       oxlint-tsgolint:
         specifier: ^7.0.2001
         version: 7.0.2001
@@ -176,60 +176,60 @@ packages:
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
-  '@corsa-bind/napi-darwin-arm64@1.13.1':
-    resolution: {integrity: sha512-t2/xpeZgd0Tz4GgbZkRyZHO9fGE48G4YXP9WHXM/RLNvAKMUTi8i1+/8ORD3meakhGrIx0LF99XEgTB/xrvLQQ==}
+  '@corsa-bind/napi-darwin-arm64@1.14.0':
+    resolution: {integrity: sha512-mFG0FwQDBflIS9ZideSlN8lo+AKIK33KaOhpT/ZdL0aqzxgKN+KfUnn99hsMZ7jU2i11hK/mCa5Ve6jhZxFh/A==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [arm64]
     os: [darwin]
 
-  '@corsa-bind/napi-darwin-x64@1.13.1':
-    resolution: {integrity: sha512-U+ojOJP4g5VXntWTzw0AWqQ6Ee8ryweRvyECb3BCFGB7sbfq1/IZQ4LwTTioXELYba5FvomwmKmAd1e8nwImzg==}
+  '@corsa-bind/napi-darwin-x64@1.14.0':
+    resolution: {integrity: sha512-PP8rt2YuiE/R4qrAONdUmxY9/dn5va25ZG0ZpfonOongh8HnCK5oRgtl/AIeweC+yjdcZ5c08MZ6cQPZumi26Q==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [x64]
     os: [darwin]
 
-  '@corsa-bind/napi-linux-arm64-gnu@1.13.1':
-    resolution: {integrity: sha512-hfF3jboHnkJ0H2itPwG/gsoOJ3RlsX+hUtjdg/oM9ESZPGQBsgGgHOKx1lpCwQUEDzIxWP5jxQZMq6yvuDS3xQ==}
+  '@corsa-bind/napi-linux-arm64-gnu@1.14.0':
+    resolution: {integrity: sha512-SH2FzN2ddRMjx9kZc+xsrPDr8jG3nB1GAZNZsh2RuVJFCnXdpIBEh7+Kv86JVQhxiT/OQJdVOnYXlcIjj00cow==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@corsa-bind/napi-linux-arm64-musl@1.13.1':
-    resolution: {integrity: sha512-+rptPo3CrkrxT3QPL7tEr25HNe77wzHcOEiV5wZVk7Nvn04eR1O8KYIVqrkWiDU1nqtfj75H/7fwCoh3OBPB8w==}
+  '@corsa-bind/napi-linux-arm64-musl@1.14.0':
+    resolution: {integrity: sha512-txh3hnnaXf1gXtY4scw3f/ZdAf9A30Z9uGLKJvw7QcnYzQJlQHXNdGtFutY0aELpXr1SBt/xIZpfvU6DOna5Hg==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@corsa-bind/napi-linux-x64-gnu@1.13.1':
-    resolution: {integrity: sha512-cAHqxDoxXRTkfsOaKE4aJzLpacoiTIw2lfLJW5eXUyZaojgI0bRtof8X4XLMXp/1t1e797yfbBemodf4euENhw==}
+  '@corsa-bind/napi-linux-x64-gnu@1.14.0':
+    resolution: {integrity: sha512-yw9qW9sSMr/fdOoJfto+KaFg0pwms8kdep83HAUjT6SmbOaRMgfsaSihVd1vyro0ieAdkDlWGXVAuZivCr8+hQ==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@corsa-bind/napi-linux-x64-musl@1.13.1':
-    resolution: {integrity: sha512-c1Uj1qo/08uZHQ2VnwqUYh9PG/FV3QQTaWLg5URyc8IWJH4AZRs25N3NwUS0/QAtIT+gGp0ZMWUfNXzlwRgZng==}
+  '@corsa-bind/napi-linux-x64-musl@1.14.0':
+    resolution: {integrity: sha512-cjDlETWEIEMO5ol1ANgXTZUFhcGgsJxg9N6Py75webu5Zv8m/YGo8DMf+2XCSf9tSXjeWxgQISovCI12TIan6Q==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@corsa-bind/napi-win32-arm64-msvc@1.13.1':
-    resolution: {integrity: sha512-GaYPquBgKsXktNJKk/Fa+kBRciXnD3BDV5mOhJ+a4Ta+ETuSZ0xZUizE02ObAf3zHeV2gOPy+B2L0rHs/w7Lxw==}
+  '@corsa-bind/napi-win32-arm64-msvc@1.14.0':
+    resolution: {integrity: sha512-8WyCC4aECOOimGhBNj9hFSxIzTVRr7dLqYso7HcWQEQCIQl8cF6cb9mAzUwnzzhM5dtVJ5+aERp5EVhHspRy1g==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [arm64]
     os: [win32]
 
-  '@corsa-bind/napi-win32-x64-msvc@1.13.1':
-    resolution: {integrity: sha512-GZRSqr7BUerOT6mgdyIOm5lRlLJf9wEYdAXm8o87sK9RULqoLVGOQ4toGhrha8DVIpHRf2FxxzV1yKtMyTbZbg==}
+  '@corsa-bind/napi-win32-x64-msvc@1.14.0':
+    resolution: {integrity: sha512-Ia84IH2WXYM77Au8XB7sN1HwOhYhzuWq4xigwDKN3Mk8tx16xrdUG2rDhf2mrirGA0pAyv0RCm54vikG/ezVcg==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     cpu: [x64]
     os: [win32]
 
-  '@corsa-bind/napi@1.13.1':
-    resolution: {integrity: sha512-0bc6lz8545ivokeimaXBcYL6yQ/rGc7aEWwLPrFXbyzj7VEUqw/wmakM/VZrL28/HOwvXrZrvp1qr66JDit1Cg==}
+  '@corsa-bind/napi@1.14.0':
+    resolution: {integrity: sha512-K8LFNN7CC/UXTCOYBTa2N/DZp7Ogn3h5yZ30OznF4FWiq3ZlpHzXxx7zi4zkl6QMKLXV2hIRw/W57TJ8RfHmOQ==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
 
   '@docsearch/css@4.7.0':
@@ -2054,8 +2054,8 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  corsa-oxlint@1.13.1:
-    resolution: {integrity: sha512-B41OA1XAx3XWf9ITFD6hVKb4ik1CZxy2aKj349jGNwx7MOsBAubnynKKoSObEEUaW9FuiT33U3TCcEFhb4z/eg==}
+  corsa-oxlint@1.14.0:
+    resolution: {integrity: sha512-g6IPEBmOqrlUhXorBI55ZsXi4OfFMnTiyAUkS2iGkpIg/3S1pa8hV+Z832W/Ud4gLSYFokJa4nL/IxMtMNAJJQ==}
     engines: {bun: '>=1.2', deno: '>=2.0', node: '>=22'}
     peerDependencies:
       '@oxlint/plugins': ^1.69.0
@@ -3064,40 +3064,40 @@ snapshots:
 
   '@blazediff/core@1.9.1': {}
 
-  '@corsa-bind/napi-darwin-arm64@1.13.1':
+  '@corsa-bind/napi-darwin-arm64@1.14.0':
     optional: true
 
-  '@corsa-bind/napi-darwin-x64@1.13.1':
+  '@corsa-bind/napi-darwin-x64@1.14.0':
     optional: true
 
-  '@corsa-bind/napi-linux-arm64-gnu@1.13.1':
+  '@corsa-bind/napi-linux-arm64-gnu@1.14.0':
     optional: true
 
-  '@corsa-bind/napi-linux-arm64-musl@1.13.1':
+  '@corsa-bind/napi-linux-arm64-musl@1.14.0':
     optional: true
 
-  '@corsa-bind/napi-linux-x64-gnu@1.13.1':
+  '@corsa-bind/napi-linux-x64-gnu@1.14.0':
     optional: true
 
-  '@corsa-bind/napi-linux-x64-musl@1.13.1':
+  '@corsa-bind/napi-linux-x64-musl@1.14.0':
     optional: true
 
-  '@corsa-bind/napi-win32-arm64-msvc@1.13.1':
+  '@corsa-bind/napi-win32-arm64-msvc@1.14.0':
     optional: true
 
-  '@corsa-bind/napi-win32-x64-msvc@1.13.1':
+  '@corsa-bind/napi-win32-x64-msvc@1.14.0':
     optional: true
 
-  '@corsa-bind/napi@1.13.1':
+  '@corsa-bind/napi@1.14.0':
     optionalDependencies:
-      '@corsa-bind/napi-darwin-arm64': 1.13.1
-      '@corsa-bind/napi-darwin-x64': 1.13.1
-      '@corsa-bind/napi-linux-arm64-gnu': 1.13.1
-      '@corsa-bind/napi-linux-arm64-musl': 1.13.1
-      '@corsa-bind/napi-linux-x64-gnu': 1.13.1
-      '@corsa-bind/napi-linux-x64-musl': 1.13.1
-      '@corsa-bind/napi-win32-arm64-msvc': 1.13.1
-      '@corsa-bind/napi-win32-x64-msvc': 1.13.1
+      '@corsa-bind/napi-darwin-arm64': 1.14.0
+      '@corsa-bind/napi-darwin-x64': 1.14.0
+      '@corsa-bind/napi-linux-arm64-gnu': 1.14.0
+      '@corsa-bind/napi-linux-arm64-musl': 1.14.0
+      '@corsa-bind/napi-linux-x64-gnu': 1.14.0
+      '@corsa-bind/napi-linux-x64-musl': 1.14.0
+      '@corsa-bind/napi-win32-arm64-msvc': 1.14.0
+      '@corsa-bind/napi-win32-x64-msvc': 1.14.0
 
   '@docsearch/css@4.7.0': {}
 
@@ -3862,19 +3862,19 @@ snapshots:
       vite: '@voidzero-dev/vite-plus-core@0.2.9(@types/node@24.10.15)(jiti@2.6.1)(typescript@7.0.2)(yaml@2.8.1)'
       vue: 3.5.41(typescript@7.0.2)
 
-  '@vitest/browser-preview@4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10)':
+  '@vitest/browser-preview@4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1)))':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.6(@testing-library/dom@10.4.1)
-      '@vitest/browser': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10)
-      vitest: 4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))
+      '@vitest/browser': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1)))
+      vitest: 4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10))(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10)':
+  '@vitest/browser@4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1)))':
     dependencies:
       '@blazediff/core': 1.9.1
       '@vitest/mocker': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))
@@ -3883,7 +3883,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))
+      vitest: 4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10))(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
@@ -4320,9 +4320,9 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  corsa-oxlint@1.13.1(@oxlint/plugins@1.81.0)(oxlint@1.81.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.3.0(@types/node@24.10.15)(jiti@2.6.1)(typescript@7.0.2)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(yaml@2.8.1))):
+  corsa-oxlint@1.14.0(@oxlint/plugins@1.81.0)(oxlint@1.81.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.3.0(@types/node@24.10.15)(jiti@2.6.1)(typescript@7.0.2)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(yaml@2.8.1))):
     dependencies:
-      '@corsa-bind/napi': 1.13.1
+      '@corsa-bind/napi': 1.14.0
       '@oxlint/plugins': 1.81.0
       oxlint: 1.81.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.3.0(@types/node@24.10.15)(jiti@2.6.1)(typescript@7.0.2)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(yaml@2.8.1))
 
@@ -5401,8 +5401,8 @@ snapshots:
     dependencies:
       '@oxc-project/types': 0.146.0
       '@oxlint/plugins': 1.79.0
-      '@vitest/browser': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10)
-      '@vitest/browser-preview': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10)
+      '@vitest/browser': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1)))
+      '@vitest/browser-preview': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1)))
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))
       '@vitest/pretty-format': 4.1.11
@@ -5414,7 +5414,7 @@ snapshots:
       oxfmt: 0.64.0(vite-plus@0.3.0(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(yaml@2.8.1))
       oxlint: 1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.3.0(@types/node@24.10.15)(jiti@2.6.1)(typescript@6.0.3)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(yaml@2.8.1))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))
+      vitest: 4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10))(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.3.0
       '@voidzero-dev/vite-plus-darwin-x64': 0.3.0
@@ -5459,8 +5459,8 @@ snapshots:
     dependencies:
       '@oxc-project/types': 0.146.0
       '@oxlint/plugins': 1.79.0
-      '@vitest/browser': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10)
-      '@vitest/browser-preview': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10)
+      '@vitest/browser': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1)))
+      '@vitest/browser-preview': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1)))
       '@vitest/expect': 4.1.11
       '@vitest/mocker': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))
       '@vitest/pretty-format': 4.1.11
@@ -5472,7 +5472,7 @@ snapshots:
       oxfmt: 0.64.0(vite-plus@0.3.0(@types/node@24.10.15)(jiti@2.6.1)(typescript@7.0.2)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(yaml@2.8.1))
       oxlint: 1.79.0(oxlint-tsgolint@7.0.2001)(vite-plus@0.3.0(@types/node@24.10.15)(jiti@2.6.1)(typescript@7.0.2)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(yaml@2.8.1))
       oxlint-tsgolint: 7.0.2001
-      vitest: 4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))
+      vitest: 4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10))(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))
     optionalDependencies:
       '@voidzero-dev/vite-plus-darwin-arm64': 0.3.0
       '@voidzero-dev/vite-plus-darwin-x64': 0.3.0
@@ -5600,7 +5600,7 @@ snapshots:
       - unrun
       - yaml
 
-  vitest@4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1)):
+  vitest@4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10))(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))
@@ -5624,7 +5624,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.15
-      '@vitest/browser-preview': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10)
+      '@vitest/browser-preview': 4.1.11(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1))(vitest@4.1.10(@types/node@24.10.15)(@vitest/browser-preview@4.1.11)(vite@7.1.12(@types/node@24.10.15)(jiti@2.6.1)(lightningcss@1.33.0)(yaml@2.8.1)))
     transitivePeerDependencies:
       - msw
 


### PR DESCRIPTION
### Issue # (if applicable)

N/A — dependency bump requested by the maintainer, plus the performance work it enabled.

### Reason for this change

**The bump.** corsa-oxlint 1.13.2–1.14.0 fixed several `getTypeAtLocation` mis-resolutions that this plugin works around or is limited by. corsa-bind#479 (released in 1.13.2) closed the upstream report about call / `[]` / `?:` / `await` receivers, and the remaining fixes landed by 1.14.0. Measured on this branch against 1.13.1, the resolutions that changed are:

| expression | 1.13.1 | 1.14.0 |
| --- | --- | --- |
| `topics[0]` (computed member on an array) | `Topic[]` | `Topic` |
| `flag ? a : b` | `boolean` | `Topic \| Queue` |
| `PropertyDefinition` with `!` | `any` | `Bucket` |
| `PropertyDefinition` with `?` | `any` | `Bucket \| undefined` |
| `TSArrayType` / `TSTupleType` / `TSUnionType` / `TSIntersectionType` annotation nodes | `any` | the annotated type |
| parameterized `TSTypeReference` node | `Box<T>` | `Box<Bucket>` |

**The performance work.** On a generated 26k-line CDK-shaped fixture (300 Construct classes, all 17 rules, type-aware), the rules made **320,690 checker calls** and cost **3,928ms** over the no-plugin floor of 98ms. The ESLint plugin's rules answer the same questions on the same input in **237ms** over its own floor, because TypeScript's checker is in-process — so the gap is the corsa transport, not the algorithms.

That 320,690 counts calls into the checker wrapper the rules hold, not transport round trips: corsa-oxlint's session already caches `getTypeAtSourceRange` by file and range, and `getSymbolOfType` and `getBaseTypes` by type id, so a share of those calls were served locally. What still crosses the transport on every call includes `getSignaturesOfType`, `typeToString`, and the `typeToString` fallbacks inside `getBaseTypes` and constructor-base resolution — and it is those calls that the measured wall-clock gains come from.

The calls were near-duplicates: the base-type walk behind `isConstructType`, the construct signature behind `findConstructorPropertyNames`, and the enclosing-class lookup were each re-asked once per AST node, although a file mentions only a handful of distinct types. Several rules also resolved a node's type before a free syntactic guard that would have rejected it.

### Description of changes

**Bump.** The exact `corsa-oxlint` pin in `packages/oxlint/package.json` moves from 1.13.1 to 1.14.0, with the lockfile. `oxlint`, `@oxlint/plugins`, `oxlint-tsgolint` and `typescript` are unchanged: corsa-oxlint 1.14.0 declares `@oxlint/plugins ^1.69.0` and `oxlint ^1.69.0`, both already satisfied by the `^1.81.0` ranges in this repo. Across the whole published `dist` tree only `dist/checker.js` differs between the two versions; every `.d.ts` is byte-identical, so the bump is behavioural only.

Because 1.14.0 resolves `topics[0]` on a `Topic[]` to the element type, the receiver that `prefer-grants-property` had to skip on 1.13.1 now resolves. The fixture that pinned that limitation moves from `valid` to `invalid`, matching the ESLint plugin, and the two NOTEs naming 1.13.1 are dropped.

The lockfile diff also re-serializes the peer-suffixed keys of `vitest` / `@vitest/browser` / `@vitest/browser-preview` / `vite-plus` into their fully qualified form. That churn is not caused by this bump: with `corsa-oxlint` left at 1.13.1 and an unrelated spec touched instead, pnpm 10.29.3 rewrites exactly the same 14 lines. No resolved version changes in those entries.

Audit follow-ups, **not included in this PR** — measured on this branch at 1.14.0, none of the corsa-specific workarounds in `packages/oxlint` turned out to be removable:

- `enclosing-loop-body.ts` still needs `| null`; annotating `ESTree.Node | undefined` fails with TS2322 on `return parent.body` for the iteration-callback branch.
- The `.some((type) => type === node.type)` form in `enclosing-method.ts` and `sibling-construct-id-strings.ts` still cannot become `Array.prototype.includes` (TS2345). This is the ordinary `as const` narrowing rule rather than a corsa defect, so no upstream fix will change it.
- The union / intersection bail-out in `is-extends-target-super-class.ts` stays: `checker.getBaseTypes(Alpha | Beta)` still returns the union's members, so the NOTE's factual claim is unchanged.
- `CorsaTypeCheckerShape` still exposes no `getNonNullableType`, so the manual filter in `non-nullable-type.ts` stays. This is also the actual cause of the `no-unused-props` divergence for `props?: A | B`: the oxlint finder can only select a single surviving member, so a union with two non-nullish members is returned unchanged and no property is tracked, while eslint's `getNonNullableType` rebuilds `A | B` and tracks the shared ones. The required-union case (`props: A | B`) already behaves identically in both plugins.
- The key-based type resolution in `no-construct-in-public-property-of-construct.ts` stays as the canonical design; `node.key` and the now-fixed `PropertyDefinition` node resolve to the same type on 1.14.0.

**Performance.** Two changes, both behaviour-neutral:

- Memoize the corsa type queries whose answers depend only on their arguments. `createTypeQueryMemo` keys results on the checker (a rule holds one per file, so entries live exactly as long as the snapshot) and on `CorsaType.id`, the identity corsa itself caches base types and symbols by. `findTypeAtLocation` does the same for a node's type, keyed on the parser services and the AST node. `no-construct-in-public-property-of-construct` and `construct-constructor-property` now pass down the checker they already built instead of asking for a new one per property.
- Move the free syntactic guards ahead of the type resolution they gate: the argument-count check in the five construct-id rules, and the `new X(this, …)` check in `require-passing-this`. On the fixture that leaves `require-passing-this` issuing no checker calls at all, since passing `this` is the idiom the rule exists to enforce.

The memo stays in the Oxlint plugin: the cost it removes is the corsa transport, and adding the same machinery to the ESLint plugin would buy nothing against its 237ms. The guard reordering is a shared concept and is mirrored into the ESLint plugin.

**corsa-bind#480 is not reachable from a rule.** `resolveCheckerBatch` needs a `CheckerBatchCapableClient` and a `{ snapshot, project }` scope. corsa-oxlint's public surface exposes neither: `ParserServices` (`dist/types.d.ts:151-164`) reaches only `CorsaProgramShape` (`:100-109`) and `CorsaTypeCheckerShape` (`:110-150`), every method of which takes one node, symbol or type. `SessionProjectState` (`:182-186`) does hold `{ config, project, snapshot }`, but nothing returns it, it is not re-exported from `dist/index.d.ts`, and `dist/types.d.ts` is not in the package's `exports` map, so it cannot even be imported. corsa-oxlint 1.14.0 does not use the helpers itself either — `dist/session.js` and `dist/checker.js` contain no reference to `batchRequests`, `resolveCheckerBatch`, `batchCheckerRequests` or `getTypesOfSymbols`. Reaching the batch API would mean importing `@corsa-bind/napi` directly, which this repository does not do.

### Description of how you validated changes

Verified with `corsa-oxlint 1.14.0` / `@corsa-bind/napi 1.14.0` / `oxlint 1.81.0` / `@oxlint/plugins 1.81.0` / `oxlint-tsgolint 7.0.2001` / `typescript 7.0.2` resolved in `node_modules` after `vp install --frozen-lockfile`.

- `vp install --frozen-lockfile` — lockfile consistent, no diff produced.
- `vp check` — 258 files formatted, no warnings, lint errors or type errors in 155 files.
- `vp test --run` — 34 files, 836 tests passed.
- `vp run -r pack && bash scripts/integration-test.sh` — `SUCCESS` three times (43 errors, ESM / CJS / oxlint).

A new `require-passing-this` fixture in both packages instantiates a Construct and a plain class with `scope` in one file and expects exactly one report; with `CorsaType.id` removed from the memo key it reports none, so it pins that distinct types keep distinct entries.

#### Benchmark

Three configurations, each checked out, installed with `vp install --frozen-lockfile` and rebuilt with `vp run -r pack` before measuring:

1. `origin/main` at `9caea55` — corsa-oxlint 1.13.1, no change.
2. `af97133` — the bump commit only, corsa-oxlint 1.14.0.
3. `03566f1` — this PR's head, 1.14.0 plus the performance work.

Three workloads, each **1 untimed warm-up followed by 10 timed runs**, measured wall clock around the process:

| workload | working directory | command |
| --- | --- | --- |
| `examples/` | `examples` | `./node_modules/.bin/oxlint --format=unix -c .oxlintrc.json` |
| fixture A | scratch dir | `./node_modules/.bin/oxlint --format=unix -c .oxlintrc.json src` |
| fixture B | scratch dir | `./node_modules/.bin/oxlint --format=unix -c .oxlintrc.json src-mixed` |

The `examples/` command is the one `scripts/integration-test.sh` runs (`vp run -F @awscdk-lint/examples oxlint` resolves to that package script), invoked directly so the `vp run` wrapper is not timed. **It printed 43 errors on every timed run in all three configurations** — the 30 runs of the sweep below, and 30 more in the repeat sweep. The generated fixtures produce no diagnostics in any configuration, so they measure the analysis rather than the reporting path.

Fixture A is 60 files / 300 Construct classes / 26,353 lines. Fixture B is the same generator plus eight ordinary `new` expressions per construct (2,400 in total, six of the eight taking fewer than two arguments): 60 files / 300 constructs / 28,753 lines. Both live outside the repository.

**Machine**: Apple M3 Pro, 12 cores, 36 GB, macOS 14.1 (23B2073), Node 24.18.0 (the repo's `.node-version`; the scratch directory is outside any project, so that runtime was forced onto `PATH` for the fixture runs so every workload uses the same one).

| workload | 1 · main, 1.13.1 | 2 · bump, 1.14.0 | 3 · this PR | 3 vs 2 (median) |
| --- | --- | --- | --- | --- |
| `examples/` median / min / max | 684 / 677 / 765ms | 700 / 684 / 740ms | **675 / 668 / 689ms** | −3.6% |
| fixture A median / min / max | 4035 / 3963 / 4304ms | 4026 / 3990 / 4507ms | **2631 / 2606 / 2749ms** | **−34.6%** |
| fixture B median / min / max | 7306 / 7158 / 7543ms | 7357 / 7246 / 7778ms | **3946 / 3887 / 3984ms** | **−46.4%** |

n = 10 per cell. The bump on its own is not measurable on any workload: its only change to the published `dist` is `dist/checker.js`, and that diff is the resolution fixes listed above, not caching. `examples/` is 17 small files, so its ~600ms of process and project startup dominates the ~75ms of rule work.

**Run-to-run spread exceeded 5% in several cells** (worst: 12.9% on `examples/` in configuration 1, 12.8% on fixture A in configuration 2). The machine was running other unrelated build and test processes that could not be quiesced; the 1-minute load average ranged from 2.4 to 4.6 across the sweep. The interference is one-sided — it can only make a run slower — so `min` is the more robust column, and it tells the same story (fixture A −34.7%, fixture B −46.4%). The measured effect is between 5× and 9× the worst observed spread.

A second full sweep run immediately afterwards agrees, except for two cells that an unrelated process disturbed:

<details><summary>Repeat sweep (10 runs per cell)</summary>

| workload | 1 · main, 1.13.1 | 2 · bump, 1.14.0 | 3 · this PR |
| --- | --- | --- | --- |
| `examples/` median / min / max | 809 / 708 / 3122ms † | 696 / 683 / 717ms | 670 / 655 / 707ms |
| fixture A median / min / max | 4026 / 4007 / 4641ms | 4010 / 3980 / 4105ms | 2634 / 2571 / 2750ms |
| fixture B median / min / max | 8758 / 7285 / 10171ms † | 7311 / 7186 / 7824ms | 3932 / 3915 / 3978ms |

† disturbed by an unrelated process; the `min` column stays consistent with the first sweep. Every other cell reproduces its first-sweep median to within 0.6%.

</details>

<details><summary>Fixture generator</summary>

Local stand-ins only, so the fixture needs no `aws-cdk-lib`. The class hierarchy is shaped like the CDK's so that `isResourceWithReadonlyInterface` matches through the `Base` suffix:

```ts
class Construct { constructor(scope: Construct, id: string) {} }
class Stack extends Construct {}
class Resource extends Construct {}
class BucketBase extends Resource implements IBucket {}   class Bucket extends BucketBase {}
class TopicBase  extends Resource implements ITopic  {}   class Topic  extends TopicBase  {}
class QueueBase  extends Resource implements IQueue  {}   class Queue  extends QueueBase  {}
class TableBase  extends Resource implements ITable  {}   class Table  extends TableBase  {}
class FunctionBase extends Resource implements IFunction {} class Function extends FunctionBase {}
```

Each of the 300 constructs is emitted from this template (`Widget<n>`), which every rule accepts:

```ts
/** Properties for Widget0. */
export interface Widget0Props {
  /** The source bucket. */
  readonly sourceBucket: IBucket;
  /** The notification topic. */
  readonly notificationTopic: ITopic;
  /** The retry count. @default - 3 */
  readonly retryCount?: number;
  /** The display label. @default - the construct id */
  readonly label?: string;
  /** The extra queue names. */
  readonly queueNames: string[];
}

/** A generated construct used to exercise every type-aware rule. */
export class Widget0 extends Construct {
  /** The bucket the widget reads from. */
  public readonly sourceBucket: IBucket;
  /** The topic the widget publishes to. */
  public readonly notificationTopic: ITopic;
  /** The handler function. */
  public readonly handler: IFunction;
  /** The resolved label. */
  public readonly label: string;

  constructor(scope: Construct, id: string, props: Widget0Props) {
    super(scope, id);

    const assetBucket = new Bucket(this, "AssetBucket");
    const handlerFunction = new Function(this, "HandlerFunction");
    const auditTable = new Table(this, "AuditTable");
    const deadLetterQueue = new Queue(this, "DeadLetterQueue");
    const alarmTopic = new Topic(this, "AlarmTopic");

    assetBucket.grantRead(handlerFunction);
    assetBucket.grantWrite(handlerFunction);
    auditTable.grantReadData(handlerFunction);
    deadLetterQueue.grantConsumeMessages(handlerFunction);
    alarmTopic.grantPublish(handlerFunction);
    props.sourceBucket.grantRead(handlerFunction);
    props.notificationTopic.grantPublish(handlerFunction);

    for (const queueName of props.queueNames) {
      void queueName;
      new Queue(this, `LoopQueue${queueName}`);
    }

    const attempts = props.retryCount ?? 3;
    void attempts;
    // fixture B only:
    // void new Map<string, string>();          void new Set<string>();
    // void new Date();                         void new Error("boom");
    // void new RegExp("^a$");                  void new Map<string, number>([["a", 1]]);
    // void new Date(2020, 1);                  void new RegExp("^a$", "g");
    void assetBucket.bucketArn;
    void auditTable.tableArn;
    void deadLetterQueue.queueUrl;
    void alarmTopic.topicArn;

    this.sourceBucket = props.sourceBucket;
    this.notificationTopic = props.notificationTopic;
    this.handler = handlerFunction;
    this.label = props.label ?? id;
  }
}
```

The grant calls exercise `prefer-grants-property` along its full path without reporting, because none of the stub classes has a `grants` property. `.oxlintrc.json` is `examples/.oxlintrc.json` verbatim (all 17 rules at `error`, `jsPlugins: ["oxlint-plugin-awscdk"]`, `options.typeAware: true`); `tsconfig.json` is `examples/tsconfig.json` with `include: ["src", "src-mixed"]`. The fixture directory links `oxlint-plugin-awscdk` to `packages/oxlint`, and `oxlint` / `oxlint-tsgolint` / `typescript` to the copies under `examples/node_modules`, so the built plugin under test is the one each configuration produced.

</details>

Checker calls on fixture A, counted by wrapping the checker returned to each rule in a proxy and running one rule at a time:

| rule | before | after |
| --- | --- | --- |
| no-variable-construct-id | 46,800 | 8,400 |
| no-parent-name-construct-id-match | 43,200 | 6,300 |
| require-passing-this | 43,200 | 0 |
| no-construct-stack-suffix | 32,400 | 6,720 |
| pascal-case-construct-id | 32,400 | 6,720 |
| prevent-construct-id-collision | 32,400 | 6,720 |
| prefer-grants-property | 30,600 | 8,520 |
| no-construct-in-interface | 20,764 | 12,100 |
| no-construct-in-public-property-of-construct | 13,428 | 7,791 |
| require-jsdoc | 10,900 | 2,921 |
| construct-constructor-property | 6,928 | 4,145 |
| no-unused-props | 3,766 | 2,953 |
| no-mutable-public-property-of-construct | 2,556 | 1,743 |
| props-name-convention | 1,348 | 546 |
| **total** | **320,690** | **75,579** |

By method, the time those calls cost on fixture A moves from `getTypeAtLocation` 31,591 calls / 1,582ms, `getBaseTypes` 49,999 / 978ms and `getSignaturesOfType` 7,200 / 631ms to 26,189 / 1,474ms, 8,119 / 307ms and 1,200 / 106ms. `isUnionType` and `isIntersectionType` are local flag tests and cost nothing measurable either way.

### Review points

Sharing resolved node types *between* rules would remove a further ~1,000ms, but it was left out on purpose: corsa's `getTypeAtLocation` is stateful (`rememberTypeLookupFromType`), so a cache shared across rules would make a rule's answer depend on which rule ran first. The memo is therefore scoped to one rule's parser services. Removing that limit belongs upstream, where corsa-oxlint can cache node → type per snapshot safely — which is also where corsa-bind#480's coalescing would apply.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license_


